### PR TITLE
docs: update Node.js requirement from 18+ to 20+

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Positive.help is a place where people share positivity. Currently, the ability t
 
 ### Prerequisites
 
-- Node.js (version 18 or later)
+- Node.js (version 20 or later)
 - pnpm
 - Turso database credentials (URL and authentication token)
 - Clerk API keys (e.g., `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`)


### PR DESCRIPTION
Update README to reflect dropping Node.js 18 support in favor of Node.js 20+ as the minimum requirement.