### PR TITLE
fix: harden message API auth, sanitization, and DB error handling

### DIFF
--- a/__tests__/lib/validation/schemas.test.ts
+++ b/__tests__/lib/validation/schemas.test.ts
@@ -27,19 +27,20 @@ describe("Validation Schemas with Sanitization", () => {
 			expect(result.text).not.toContain("onerror");
 		});
 
-		it("should sanitize SQL injection keywords", () => {
-			const maliciousInput = {
+		it("should preserve content that looks like SQL (injection protection is via parameterized queries)", () => {
+			const input = {
 				text: "Nice message'; DROP TABLE messages; SELECT * FROM users; --",
 				clerkUserId: "user_123",
 			};
 
-			const result = messageSchemas.create.parse(maliciousInput);
-			// The sanitizer removes dangerous SQL keywords (DROP, SELECT, FROM) but keeps common words (TABLE, messages)
-			// Apostrophes are preserved to support contractions like "don't", "it's", etc.
-			expect(result.text).toBe("Nice message' TABLE messages users --");
-			expect(result.text).not.toContain("DROP");
-			expect(result.text).not.toContain("SELECT");
-			expect(result.text).not.toContain("FROM");
+			const result = messageSchemas.create.parse(input);
+			// The sanitizer no longer strips SQL keywords: doing so mangled legitimate
+			// content (e.g. "from", "where", "update") and provided zero injection
+			// protection, since all DB access uses parameterized libSQL queries.
+			// Only special characters (";", "*") and apostrophes-aside punctuation differ.
+			expect(result.text).toBe(
+				"Nice message' DROP TABLE messages SELECT FROM users --",
+			);
 		});
 
 		it("should remove malicious URLs", () => {
@@ -85,11 +86,12 @@ describe("Validation Schemas with Sanitization", () => {
 			};
 
 			const result = messageSchemas.create.parse(mixedInput);
+			// HTML and script tags are stripped; legitimate words (including "SELECT")
+			// are preserved.
 			expect(result.text).toBe(
-				"This is a good message with some bad keywords and",
+				"This is a good message with SELECT some bad keywords and",
 			);
 			expect(result.text).not.toContain("<b>");
-			expect(result.text).not.toContain("SELECT");
 			expect(result.text).not.toContain("<script>");
 		});
 

--- a/__tests__/utils/sanitize.test.ts
+++ b/__tests__/utils/sanitize.test.ts
@@ -29,9 +29,9 @@ describe("sanitizeContent", () => {
 			expect(sanitizeContent("Visit https://example.com")).toBe("Visit");
 		});
 
-		it("should remove FTP URLs", () => {
+		it("should remove FTP URLs while preserving surrounding words", () => {
 			expect(sanitizeContent("Download from ftp://files.example.com")).toBe(
-				"Download",
+				"Download from",
 			);
 		});
 	});
@@ -70,15 +70,28 @@ describe("sanitizeContent", () => {
 		});
 	});
 
-	describe("SQL keyword removal", () => {
-		it("should remove basic SQL keywords", () => {
-			expect(sanitizeContent("SELECT * FROM users")).toBe("users");
-			expect(sanitizeContent("DROP TABLE students")).toBe("TABLE students");
+	describe("SQL keyword preservation", () => {
+		it("should preserve common English words that overlap with SQL keywords", () => {
+			expect(sanitizeContent("A message from the heart")).toBe(
+				"A message from the heart",
+			);
+			expect(sanitizeContent("Where there is love")).toBe(
+				"Where there is love",
+			);
+			expect(sanitizeContent("Update your outlook and join us")).toBe(
+				"Update your outlook and join us",
+			);
 		});
 
-		it("should remove SQL keywords regardless of case", () => {
-			expect(sanitizeContent("Select From Where")).toBe("");
-			expect(sanitizeContent("INSERT into DELETE")).toBe("into");
+		it("should preserve words regardless of case (no SQL stripping)", () => {
+			expect(sanitizeContent("Select From Where")).toBe("Select From Where");
+			expect(sanitizeContent("INSERT into DELETE")).toBe("INSERT into DELETE");
+		});
+
+		it("should not provide injection protection (DB access is parameterized)", () => {
+			// Words are preserved; only the non-word "*" is stripped as a special char
+			expect(sanitizeContent("SELECT * FROM users")).toBe("SELECT FROM users");
+			expect(sanitizeContent("DROP TABLE students")).toBe("DROP TABLE students");
 		});
 	});
 
@@ -109,7 +122,7 @@ describe("sanitizeContent", () => {
         Multiple     spaces
       `;
 			expect(sanitizeContent(input)).toBe(
-				"Hello, world! Check users Special chars Multiple spaces",
+				"Hello, world! Check SELECT FROM users Special chars Multiple spaces",
 			);
 		});
 	});

--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -79,6 +79,17 @@ export async function POST(request: Request) {
 		const hash = generateMD5(text);
 		const slug = generateSlug(text, hash);
 
+		// Enforce authentication for ALL write paths (both existing-message
+		// attribution and new-message creation) before touching the database.
+		const session = await auth();
+		if (!session?.userId) {
+			throw new APIError("Authentication required", 401, "AUTH_REQUIRED");
+		}
+
+		if (session.userId !== clerkUserId) {
+			throw new APIError("User authentication mismatch", 403, "AUTH_MISMATCH");
+		}
+
 		// Check if message already exists
 		const existing = await client.execute({
 			sql: "SELECT id, slug FROM messages WHERE hash = ?",
@@ -116,20 +127,6 @@ export async function POST(request: Request) {
 			return NextResponse.json({ success: true, slug: existingSlug });
 		} else {
 			// --- Message Doesn't Exist ---
-			// Get the auth session
-			const session = await auth();
-			if (!session?.userId) {
-				throw new APIError("Authentication required", 401, "AUTH_REQUIRED");
-			}
-
-			if (session.userId !== clerkUserId) {
-				throw new APIError(
-					"User authentication mismatch",
-					403,
-					"AUTH_MISMATCH",
-				);
-			}
-
 			// Get the full user object for admin check
 			const user = await currentUser();
 			if (!user) {

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -46,7 +46,13 @@ export async function getMessages(lastId?: number): Promise<Message[]> {
 
 		return messages;
 	} catch (error) {
+		// Log then re-throw. Swallowing the error into an empty array would
+		// let a transient DB failure surface as a cacheable empty 200 response
+		// (see app/api/messages/route.ts caching), poisoning the edge cache
+		// with an empty homepage for the full max-age window. Re-throwing lets
+		// the API route's handleAPIError return an uncacheable 5xx, and the
+		// homepage server component fall through to app/error.tsx.
 		logger.error("Error fetching messages:", error);
-		return [];
+		throw error;
 	}
 }

--- a/utils/sanitize.ts
+++ b/utils/sanitize.ts
@@ -9,8 +9,6 @@ export function sanitizeContent(text: string): string {
 			.replace(/\b(?:https?|ftp):\/\/\S+\b/gi, "")
 			// Remove special characters but keep basic punctuation and apostrophes
 			.replace(/[^\w\s.,!?'-]/g, "")
-			// Remove SQL keywords (with word boundaries) - comprehensive list for injection prevention
-			.replace(/\b(SELECT|INSERT|UPDATE|DELETE|DROP|UNION|WHERE|FROM|JOIN|EXEC|EXECUTE|DECLARE|CAST|CONVERT)\b/gi, "")
 			// Trim whitespace
 			.trim()
 			// Normalize whitespace (including newlines and tabs)


### PR DESCRIPTION
## Summary

- **Security**: hoist Clerk `auth()` + userId mismatch check above the existing/new-message branch in `app/api/messages/route.ts` so the existing-message author-attribution write path now requires authentication (it was previously an unauthenticated write; middleware does not gate API routes)
- **Sanitization**: remove SQL-keyword stripping from `sanitizeContent` in `utils/sanitize.ts` that was corrupting legitimate message/author text (`FROM`, `WHERE`, `SELECT`, etc.); DB access is parameterized so the stripping provided no security value; tests updated accordingly
- **Reliability**: `getMessages` in `lib/messages.ts` now rethrows on DB error instead of returning `[]`, so a transient DB failure surfaces as an uncacheable 5xx rather than an empty homepage cached ~5 min at the edge

## Changes

### Security
- **app/api/messages/route.ts**: Hoist auth check above the existing/new-message branch; unauthenticated requests to the existing-message write path now receive 401

### Sanitization
- **utils/sanitize.ts**: Remove SQL-keyword stripping from `sanitizeContent`; DB access is parameterized so this provided no security benefit and corrupted legitimate text
- **__tests__/utils/sanitize.test.ts**: Update tests to reflect removal of keyword stripping
- **__tests__/lib/validation/schemas.test.ts**: Update schema tests accordingly

### Reliability
- **lib/messages.ts**: `getMessages` now rethrows DB errors instead of swallowing them and returning `[]`

## Test plan

- [x] 211 tests pass
- [x] Biome lint clean

## Related (deferred follow-ups, not closed by this PR)

#251, #252, #253