### PR TITLE
fix(security): hash API tokens at rest and harden rate-limit XFF trust

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@ GITHUB_SECRET=your-github-oauth-app-secret
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=your-clerk-publishable-key
 CLERK_SECRET_KEY=your-clerk-secret-key
 VERCEL_ENV=development
+
+# Rate limiter: how many rightmost x-forwarded-for hops to trust for client IP.
+# Railway (single proxy hop) → 1 (default). Direct-to-origin → 0. Cloudflare→Railway → 2.
+TRUSTED_PROXY_HOPS=1

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ next-env.d.ts
 CLAUDE.md
 AGENTS.md
 
+# local scratch / code review notes (untracked)
+/_/
+
 # beads issue tracking (uses Dolt DB locally)
 .beads/
 

--- a/__tests__/lib/rate-limit.test.ts
+++ b/__tests__/lib/rate-limit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+import { describe, it, expect, beforeEach, afterEach, jest } from "@jest/globals";
 
 // Mock Next.js modules before importing rate-limit
 jest.mock("next/headers", () => ({
@@ -27,9 +27,11 @@ jest.mock("next/server", () => ({
 }));
 
 // Import after mocking
+import { headers } from "next/headers";
 import {
 	checkRateLimit,
 	clearRateLimitStore,
+	getClientIP,
 	getRateLimitStoreSize,
 	RATE_LIMITS,
 } from "@/lib/rate-limit";
@@ -38,6 +40,128 @@ describe("rate-limit", () => {
 	beforeEach(() => {
 		// Clear the rate limit store before each test
 		clearRateLimitStore();
+	});
+
+	describe("getClientIP", () => {
+		const originalTrustedHops = process.env.TRUSTED_PROXY_HOPS;
+
+		beforeEach(() => {
+			delete process.env.TRUSTED_PROXY_HOPS;
+		});
+
+		afterEach(() => {
+			if (originalTrustedHops === undefined) {
+				delete process.env.TRUSTED_PROXY_HOPS;
+			} else {
+				process.env.TRUSTED_PROXY_HOPS = originalTrustedHops;
+			}
+			jest.mocked(headers).mockReset();
+		});
+
+		it("falls back to x-real-ip when x-forwarded-for is absent", async () => {
+			jest.mocked(headers).mockResolvedValue(
+				new Map([["x-real-ip", "203.0.113.7"]]) as unknown as Awaited<
+					ReturnType<typeof headers>
+				>,
+			);
+			const ip = await getClientIP();
+			expect(ip).toBe("203.0.113.7");
+		});
+
+		it("returns 'unknown' when no headers are present", async () => {
+			jest.mocked(headers).mockResolvedValue(
+				new Map() as unknown as Awaited<ReturnType<typeof headers>>,
+			);
+			const ip = await getClientIP();
+			expect(ip).toBe("unknown");
+		});
+
+		it("underflows to leftmost for a single XFF entry with TRUSTED_PROXY_HOPS=1", async () => {
+			process.env.TRUSTED_PROXY_HOPS = "1";
+			jest.mocked(headers).mockResolvedValue(
+				new Map([["x-forwarded-for", "1.2.3.4"]]) as unknown as Awaited<
+					ReturnType<typeof headers>
+				>,
+			);
+			const ip = await getClientIP();
+			expect(ip).toBe("1.2.3.4");
+		});
+
+		it("returns the single entry with TRUSTED_PROXY_HOPS=0", async () => {
+			process.env.TRUSTED_PROXY_HOPS = "0";
+			jest.mocked(headers).mockResolvedValue(
+				new Map([["x-forwarded-for", "1.2.3.4"]]) as unknown as Awaited<
+					ReturnType<typeof headers>
+				>,
+			);
+			const ip = await getClientIP();
+			expect(ip).toBe("1.2.3.4");
+		});
+
+		it("returns the leftmost (client) entry for two XFF entries with TRUSTED_PROXY_HOPS=1", async () => {
+			process.env.TRUSTED_PROXY_HOPS = "1";
+			jest.mocked(headers).mockResolvedValue(
+				new Map([["x-forwarded-for", "1.2.3.4, 5.6.7.8"]]) as unknown as Awaited<
+					ReturnType<typeof headers>
+				>,
+			);
+			const ip = await getClientIP();
+			expect(ip).toBe("1.2.3.4");
+		});
+
+		it("underflows to leftmost for two XFF entries with TRUSTED_PROXY_HOPS=2", async () => {
+			process.env.TRUSTED_PROXY_HOPS = "2";
+			jest.mocked(headers).mockResolvedValue(
+				new Map([["x-forwarded-for", "1.2.3.4, 5.6.7.8"]]) as unknown as Awaited<
+					ReturnType<typeof headers>
+				>,
+			);
+			const ip = await getClientIP();
+			expect(ip).toBe("1.2.3.4");
+		});
+
+		it("trims extra whitespace in malformed XFF entries", async () => {
+			process.env.TRUSTED_PROXY_HOPS = "1";
+			jest.mocked(headers).mockResolvedValue(
+				new Map([["x-forwarded-for", " 1.2.3.4 , 5.6.7.8 "]]) as unknown as Awaited<
+					ReturnType<typeof headers>
+				>,
+			);
+			const ip = await getClientIP();
+			expect(ip).toBe("1.2.3.4");
+		});
+
+		it("defaults to 1 hop when TRUSTED_PROXY_HOPS is not set", async () => {
+			jest.mocked(headers).mockResolvedValue(
+				new Map([["x-forwarded-for", "1.2.3.4, 5.6.7.8"]]) as unknown as Awaited<
+					ReturnType<typeof headers>
+				>,
+			);
+			const ip = await getClientIP();
+			expect(ip).toBe("1.2.3.4");
+		});
+
+		it("uses 0 when TRUSTED_PROXY_HOPS=0 (critical case)", async () => {
+			process.env.TRUSTED_PROXY_HOPS = "0";
+			jest.mocked(headers).mockResolvedValue(
+				new Map([["x-forwarded-for", "1.2.3.4, 5.6.7.8"]]) as unknown as Awaited<
+					ReturnType<typeof headers>
+				>,
+			);
+			const ip = await getClientIP();
+			expect(ip).toBe("5.6.7.8");
+		});
+
+		it("falls back to 1 when TRUSTED_PROXY_HOPS is invalid", async () => {
+			process.env.TRUSTED_PROXY_HOPS = "invalid";
+			jest.mocked(headers).mockResolvedValue(
+				new Map([["x-forwarded-for", "1.2.3.4, 5.6.7.8"]]) as unknown as Awaited<
+					ReturnType<typeof headers>
+				>,
+			);
+			const ip = await getClientIP();
+			expect(ip).toBe("1.2.3.4");
+		});
 	});
 
 	describe("checkRateLimit", () => {

--- a/__tests__/lib/rate-limit.test.ts
+++ b/__tests__/lib/rate-limit.test.ts
@@ -98,7 +98,7 @@ describe("rate-limit", () => {
 			expect(ip).toBe("1.2.3.4");
 		});
 
-		it("returns the leftmost (client) entry for two XFF entries with TRUSTED_PROXY_HOPS=1", async () => {
+		it("returns the rightmost (Railway-recorded) entry for two XFF entries with TRUSTED_PROXY_HOPS=1", async () => {
 			process.env.TRUSTED_PROXY_HOPS = "1";
 			jest.mocked(headers).mockResolvedValue(
 				new Map([["x-forwarded-for", "1.2.3.4, 5.6.7.8"]]) as unknown as Awaited<
@@ -106,10 +106,34 @@ describe("rate-limit", () => {
 				>,
 			);
 			const ip = await getClientIP();
-			expect(ip).toBe("1.2.3.4");
+			expect(ip).toBe("5.6.7.8");
 		});
 
-		it("underflows to leftmost for two XFF entries with TRUSTED_PROXY_HOPS=2", async () => {
+		it("ignores a client-spoofed leading XFF entry (rate-limit anti-bypass)", async () => {
+			// Attacker sends "9.9.9.9"; Railway appends the real socket IP on the
+			// right. With one trusted hop we must key on the real IP, not the spoof.
+			jest.mocked(headers).mockResolvedValue(
+				new Map([
+					["x-forwarded-for", "9.9.9.9, 203.0.113.5"],
+				]) as unknown as Awaited<ReturnType<typeof headers>>,
+			);
+			const ip = await getClientIP();
+			expect(ip).toBe("203.0.113.5");
+		});
+
+		it("selects the client entry behind two trusted hops (Cloudflare→Railway)", async () => {
+			process.env.TRUSTED_PROXY_HOPS = "2";
+			// spoof, real client (added by CF), CF ip (added by Railway)
+			jest.mocked(headers).mockResolvedValue(
+				new Map([
+					["x-forwarded-for", "9.9.9.9, 203.0.113.5, 10.0.0.1"],
+				]) as unknown as Awaited<ReturnType<typeof headers>>,
+			);
+			const ip = await getClientIP();
+			expect(ip).toBe("203.0.113.5");
+		});
+
+		it("returns the leftmost entry for two XFF entries with TRUSTED_PROXY_HOPS=2", async () => {
 			process.env.TRUSTED_PROXY_HOPS = "2";
 			jest.mocked(headers).mockResolvedValue(
 				new Map([["x-forwarded-for", "1.2.3.4, 5.6.7.8"]]) as unknown as Awaited<
@@ -128,7 +152,7 @@ describe("rate-limit", () => {
 				>,
 			);
 			const ip = await getClientIP();
-			expect(ip).toBe("1.2.3.4");
+			expect(ip).toBe("5.6.7.8");
 		});
 
 		it("defaults to 1 hop when TRUSTED_PROXY_HOPS is not set", async () => {
@@ -138,7 +162,7 @@ describe("rate-limit", () => {
 				>,
 			);
 			const ip = await getClientIP();
-			expect(ip).toBe("1.2.3.4");
+			expect(ip).toBe("5.6.7.8");
 		});
 
 		it("uses 0 when TRUSTED_PROXY_HOPS=0 (critical case)", async () => {
@@ -160,7 +184,7 @@ describe("rate-limit", () => {
 				>,
 			);
 			const ip = await getClientIP();
-			expect(ip).toBe("1.2.3.4");
+			expect(ip).toBe("5.6.7.8");
 		});
 	});
 

--- a/__tests__/lib/tokens.test.ts
+++ b/__tests__/lib/tokens.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "@jest/globals";
+import {
+	generateAPIToken,
+	hashToken,
+	verifyApiToken,
+} from "@/lib/tokens";
+
+describe("tokens", () => {
+	describe("generateAPIToken", () => {
+		it("returns a string starting with ph_", () => {
+			const token = generateAPIToken();
+			expect(token.startsWith("ph_")).toBe(true);
+		});
+
+		it("produces unique tokens on successive calls", () => {
+			const a = generateAPIToken();
+			const b = generateAPIToken();
+			const c = generateAPIToken();
+			expect(a).not.toBe(b);
+			expect(b).not.toBe(c);
+			expect(a).not.toBe(c);
+		});
+	});
+
+	describe("hashToken", () => {
+		it("produces a 64-character hex digest", () => {
+			const hash = hashToken("ph_test-token");
+			expect(hash).toMatch(/^[a-f0-9]{64}$/);
+		});
+
+		it("is deterministic for the same input", () => {
+			const a = hashToken("ph_test-token");
+			const b = hashToken("ph_test-token");
+			expect(a).toBe(b);
+		});
+
+		it("produces different hashes for different inputs", () => {
+			const a = hashToken("ph_token-one");
+			const b = hashToken("ph_token-two");
+			expect(a).not.toBe(b);
+		});
+	});
+
+	describe("verifyApiToken", () => {
+		it("returns true for a matching token/hash pair", () => {
+			const token = "ph_match-me";
+			const stored = hashToken(token);
+			expect(verifyApiToken(token, stored)).toBe(true);
+		});
+
+		it("returns false for a mismatched token", () => {
+			const stored = hashToken("ph_correct-token");
+			expect(verifyApiToken("ph_wrong-token", stored)).toBe(false);
+		});
+
+		it("returns false for a too-short stored hash", () => {
+			const token = "ph_some-token";
+			expect(verifyApiToken(token, "abc123")).toBe(false);
+		});
+
+		it("returns false for a too-long stored hash", () => {
+			const token = "ph_some-token";
+			const tooLong = "a".repeat(65);
+			expect(verifyApiToken(token, tooLong)).toBe(false);
+		});
+
+		it("returns false for an empty stored hash", () => {
+			const token = "ph_some-token";
+			expect(verifyApiToken(token, "")).toBe(false);
+		});
+
+		it("does not throw for valid inputs", () => {
+			const token = "ph_smoke-test";
+			const stored = hashToken(token);
+			expect(() => verifyApiToken(token, stored)).not.toThrow();
+		});
+	});
+});

--- a/app/api/tokens/route.ts
+++ b/app/api/tokens/route.ts
@@ -6,7 +6,7 @@ import { apiTokens } from "@/db/schema";
 import { APIError, handleAPIError } from "@/lib/error-handler";
 import logger from "@/lib/logger";
 import { applyRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
-import { generateAPIToken } from "@/lib/tokens";
+import { generateAPIToken, hashToken } from "@/lib/tokens";
 
 /**
  * GET /api/tokens
@@ -81,13 +81,14 @@ export async function POST(request: Request) {
 
 		// Generate the token
 		const token = generateAPIToken();
+		const tokenHash = hashToken(token);
 		const createdAt = new Date().toISOString();
 
-		// Insert into database
+		// Insert into database (store the hash, not the raw token)
 		const result = await db
 			.insert(apiTokens)
 			.values({
-				token,
+				token: tokenHash,
 				clerkUserId: user.id,
 				name,
 				createdAt,

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -102,11 +102,16 @@ export const messageAuthorsRelations = relations(
 	}),
 );
 
-// API Tokens for desktop app authentication
+// API Tokens for desktop app authentication.
+// NOTE: the `token` column stores a SHA-256 hex hash of the raw ph_ token,
+// not the token itself. The raw token is shown to the user only at creation
+// time (POST /api/tokens). Verification compares a SHA-256 hash of the
+// presented token against this stored hash.
 export const apiTokens = sqliteTable(
 	"api_tokens",
 	{
 		id: integer("id", { mode: "number" }).primaryKey(),
+		// SHA-256 hex hash of the raw ph_ token (NOT the raw token)
 		token: text("token").notNull().unique(),
 		clerkUserId: text("clerkUserId").notNull(),
 		name: text("name").notNull().default("Desktop App"),

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -51,16 +51,25 @@ function cleanupExpiredEntries(windowMs: number): void {
 }
 
 /**
- * Get the client IP address from request headers
+ * Get the client IP address from request headers.
+ *
+ * Trust model: Railway terminates TLS and adds the client IP as the rightmost
+ * XFF entry. TRUSTED_PROXY_HOPS=1 (default) trusts that one hop. Set to 0 for
+ * direct-to-origin deploys (uses leftmost/client-supplied XFF — only safe with
+ * no proxy). Set to 2 if behind Cloudflare→Railway.
  */
 export async function getClientIP(): Promise<string> {
 	const headersList = await headers();
 
-	// Railway uses x-forwarded-for for client IP
+	const parsed = Number.parseInt(process.env.TRUSTED_PROXY_HOPS ?? "1", 10);
+	const trustedHops = Number.isFinite(parsed) ? Math.max(0, parsed) : 1;
+
+	// x-forwarded-for is a comma-separated list; rightmost entries are added by
+	// trusted proxies, leftmost is client-supplied.
 	const forwarded = headersList.get("x-forwarded-for");
 	if (forwarded) {
-		// x-forwarded-for can contain multiple IPs, take the first one (client)
-		return forwarded.split(",")[0].trim();
+		const ips = forwarded.split(",").map((entry) => entry.trim());
+		return ips[Math.max(0, ips.length - 1 - trustedHops)];
 	}
 
 	// Fallback headers

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -53,10 +53,13 @@ function cleanupExpiredEntries(windowMs: number): void {
 /**
  * Get the client IP address from request headers.
  *
- * Trust model: Railway terminates TLS and adds the client IP as the rightmost
- * XFF entry. TRUSTED_PROXY_HOPS=1 (default) trusts that one hop. Set to 0 for
- * direct-to-origin deploys (uses leftmost/client-supplied XFF — only safe with
- * no proxy). Set to 2 if behind Cloudflare→Railway.
+ * Trust model: trusted reverse proxies append to the RIGHT of `x-forwarded-for`,
+ * so the real client IP is the entry `TRUSTED_PROXY_HOPS` positions from the
+ * right end. Railway adds one hop, so TRUSTED_PROXY_HOPS=1 (default) selects the
+ * rightmost entry — the one Railway recorded — and ignores any client-supplied
+ * entries to its left (which would otherwise allow a rate-limit bypass via a
+ * forged XFF header). Set to 2 behind Cloudflare→Railway, or 0 for a
+ * direct-to-origin deploy with no proxy (XFF is then untrusted).
  */
 export async function getClientIP(): Promise<string> {
 	const headersList = await headers();
@@ -64,12 +67,17 @@ export async function getClientIP(): Promise<string> {
 	const parsed = Number.parseInt(process.env.TRUSTED_PROXY_HOPS ?? "1", 10);
 	const trustedHops = Number.isFinite(parsed) ? Math.max(0, parsed) : 1;
 
-	// x-forwarded-for is a comma-separated list; rightmost entries are added by
-	// trusted proxies, leftmost is client-supplied.
+	// x-forwarded-for is a comma-separated list; trusted proxies append on the
+	// right, so the client IP is `trustedHops` entries from the right. Clamp into
+	// range so short lists / oversized hop counts fall back to a defined entry.
 	const forwarded = headersList.get("x-forwarded-for");
 	if (forwarded) {
 		const ips = forwarded.split(",").map((entry) => entry.trim());
-		return ips[Math.max(0, ips.length - 1 - trustedHops)];
+		const index = Math.min(
+			ips.length - 1,
+			Math.max(0, ips.length - trustedHops),
+		);
+		return ips[index];
 	}
 
 	// Fallback headers

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -11,3 +11,35 @@ export function generateAPIToken(): string {
 	const token = randomBytes.toString("base64url");
 	return `ph_${token}`;
 }
+
+/**
+ * Hashes a raw API token with SHA-256 for safe at-rest storage.
+ * The returned hex digest is what gets persisted in the api_tokens.token column.
+ *
+ * @param token - The raw `ph_`-prefixed token presented by the client
+ * @returns A 64-character lowercase hex SHA-256 digest
+ */
+export function hashToken(token: string): string {
+	return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+/**
+ * Verifies a presented token against a stored SHA-256 hash using a
+ * constant-time comparison to mitigate timing attacks.
+ *
+ * @param presentedToken - The raw `ph_`-prefixed token from the client
+ * @param storedHash - The SHA-256 hex digest persisted in the database
+ * @returns true if the presented token hashes to the stored hash
+ */
+export function verifyApiToken(
+	presentedToken: string,
+	storedHash: string,
+): boolean {
+	const presentedHash = hashToken(presentedToken);
+	const a = Buffer.from(presentedHash, "utf8");
+	const b = Buffer.from(storedHash, "utf8");
+	if (a.length !== b.length) {
+		return false;
+	}
+	return crypto.timingSafeEqual(a, b);
+}

--- a/scripts/backfill-token-hashes.ts
+++ b/scripts/backfill-token-hashes.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env tsx
+// Run with: pnpm exec tsx scripts/backfill-token-hashes.ts
+//
+// Data backfill for GH #251: hashes existing plaintext `ph_` tokens in the
+// api_tokens.token column in place so they match the new at-rest format
+// (SHA-256 hex digest). The schema migration is a no-op since the column
+// type is unchanged (still `text`). Idempotent: rows whose token already
+// starts with `ph_` are hashed; rows that are already hashes (no `ph_`
+// prefix) are skipped, so running this twice is safe.
+
+import { eq } from "drizzle-orm";
+import { db } from "../db/client";
+import { apiTokens } from "../db/schema";
+import { hashToken } from "../lib/tokens";
+
+async function backfillTokenHashes(): Promise<void> {
+	const rows = await db
+		.select({ id: apiTokens.id, token: apiTokens.token })
+		.from(apiTokens);
+
+	const toBackfill = rows.filter((row) => row.token.startsWith("ph_"));
+
+	if (toBackfill.length === 0) {
+		console.log("✅ No plaintext tokens to backfill.");
+		return;
+	}
+
+	console.log(`Found ${toBackfill.length} plaintext token(s) to hash...`);
+
+	await db.transaction(async (tx) => {
+		for (const row of toBackfill) {
+			const tokenHash = hashToken(row.token);
+			await tx
+				.update(apiTokens)
+				.set({ token: tokenHash })
+				.where(eq(apiTokens.id, row.id));
+		}
+	});
+
+	console.log(`✅ Hashed ${toBackfill.length} of ${rows.length} api_tokens row(s).`);
+}
+
+backfillTokenHashes()
+	.then(() => process.exit(0))
+	.catch((error) => {
+		console.error("❌ Error backfilling token hashes:", error);
+		process.exit(1);
+	});


### PR DESCRIPTION
## Summary

- API tokens are now stored as SHA-256 hex digests in the `api_tokens` table instead of plaintext; the raw `ph_` token is returned to the user only once at creation time. An idempotent backfill script hashes existing rows in place inside a single transaction.
- `getClientIP()` now derives the client IP from a trusted proxy hop (`TRUSTED_PROXY_HOPS`, default 1 for Railway) instead of the spoofable leftmost `x-forwarded-for` entry, closing a rate-limit bypass vector.
- Added test coverage for the new crypto helpers (`hashToken`, `verifyApiToken`) and the XFF parsing edge cases including the `TRUSTED_PROXY_HOPS=0` critical case.

## Changes

### Security
- **lib/tokens.ts**: Added `hashToken()` (SHA-256 hex) and `verifyApiToken()` (constant-time compare via `crypto.timingSafeEqual`).
- **app/api/tokens/route.ts**: POST handler now stores `hashToken(token)` in the DB while still returning the raw token as `value` once at creation.
- **db/schema.ts**: Added documentation comments clarifying the `token` column stores a SHA-256 hash, not the raw token.
- **lib/rate-limit.ts**: Rewrote `getClientIP()` to use `TRUSTED_PROXY_HOPS` (rightmost XFF entry minus trusted hops) instead of the leftmost spoofable entry.

### Tooling
- **scripts/backfill-token-hashes.ts**: New idempotent tsx script that hashes existing plaintext `ph_` tokens in place within a single DB transaction.
- **.env.example**: Documented `TRUSTED_PROXY_HOPS` with recommended values for Railway, direct-to-origin, and Cloudflare→Railway.

### Tests
- **__tests__/lib/tokens.test.ts**: New test suite covering `generateAPIToken`, `hashToken` (determinism, hex format), and `verifyApiToken` (match, mismatch, length rejection, no-throw).
- **__tests__/lib/rate-limit.test.ts**: Added 10 tests for `getClientIP` covering XFF parsing, the `TRUSTED_PROXY_HOPS=0` critical case, defaults, invalid values, whitespace trimming, and fallbacks.

## Test plan

- [x] `pnpm run bun-tsc` per-file (all modified files) — zero TS errors
- [x] `pnpm test` — 17 suites, 232 tests, all passing
- [x] `pnpm exec biome lint .` — clean
- [ ] Run `pnpm exec tsx scripts/backfill-token-hashes.ts` against the production DB after deploy to migrate existing tokens

Closes #251