### PR TITLE
chore(maintenance): consolidate dependency updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/.pnpm-store/
 /.pnp
 .pnp.*
 .yarn/*

--- a/__tests__/app/api/admin/submissions-approve.test.ts
+++ b/__tests__/app/api/admin/submissions-approve.test.ts
@@ -1,0 +1,178 @@
+/** @jest-environment node */
+
+import { currentUser } from "@clerk/nextjs/server";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { NextRequest } from "next/server";
+import { POST } from "@/app/api/admin/submissions/[id]/approve/route";
+import { db } from "@/db/client";
+import { isUserAdmin } from "@/lib/auth";
+import { SUBMISSION_STATUS } from "@/lib/constants";
+import { applyRateLimit } from "@/lib/rate-limit";
+
+jest.mock("@clerk/nextjs/server", () => ({
+	currentUser: jest.fn(),
+}));
+
+jest.mock("@/db/client", () => ({
+	db: {
+		transaction: jest.fn(),
+	},
+}));
+
+jest.mock("@/lib/auth", () => ({
+	isUserAdmin: jest.fn(),
+}));
+
+jest.mock("@/lib/logger", () => ({
+	__esModule: true,
+	default: {
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+	},
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+	applyRateLimit: jest.fn(),
+	RATE_LIMITS: { ADMIN: { windowMs: 1, maxRequests: 1 } },
+}));
+
+type FakeTransaction = ReturnType<typeof createFakeTransaction>;
+
+function createFakeTransaction() {
+	const claimReturning = jest.fn<() => Promise<unknown[]>>();
+	const claimWhere = jest.fn(() => ({ returning: claimReturning }));
+	const claimSet = jest.fn(() => ({ where: claimWhere }));
+	const update = jest.fn(() => ({ set: claimSet }));
+
+	const statusWhere = jest.fn<() => Promise<Array<{ status: number }>>>();
+	const selectFrom = jest.fn(() => ({ where: statusWhere }));
+	const select = jest.fn(() => ({ from: selectFrom }));
+
+	const messageReturning = jest.fn<() => Promise<Array<{ id: number }>>>();
+	const insertValues = jest.fn(() => ({ returning: messageReturning }));
+	const insert = jest.fn(() => ({ values: insertValues }));
+
+	return {
+		tx: { update, select, insert },
+		claimReturning,
+		statusWhere,
+		messageReturning,
+		insert,
+	};
+}
+
+type AsyncMock = {
+	mockResolvedValue(value: unknown): void;
+};
+
+const transactionMock = db.transaction as unknown as {
+	mockImplementation(
+		implementation: (callback: unknown) => Promise<unknown>,
+	): void;
+};
+const currentUserMock = currentUser as unknown as AsyncMock;
+const isUserAdminMock = isUserAdmin as unknown as AsyncMock;
+const applyRateLimitMock = applyRateLimit as unknown as AsyncMock;
+
+async function approveSubmission() {
+	return POST({} as NextRequest, {
+		params: Promise.resolve({ id: "123" }),
+	});
+}
+
+function runTransactionWith(
+	fake: FakeTransaction,
+	onRollback?: () => void,
+): void {
+	transactionMock.mockImplementation(async (callback: unknown) => {
+		try {
+			return await (
+				callback as (tx: FakeTransaction["tx"]) => Promise<unknown>
+			)(fake.tx);
+		} catch (error) {
+			onRollback?.();
+			throw error;
+		}
+	});
+}
+
+describe("submission approval transaction", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		currentUserMock.mockResolvedValue({ id: "admin-user" });
+		isUserAdminMock.mockResolvedValue(true);
+		applyRateLimitMock.mockResolvedValue(null);
+	});
+
+	it("returns 409 without publishing a denied submission", async () => {
+		const fake = createFakeTransaction();
+		fake.claimReturning.mockResolvedValue([]);
+		fake.statusWhere.mockResolvedValue([{ status: SUBMISSION_STATUS.DENIED }]);
+		runTransactionWith(fake);
+
+		const response = await approveSubmission();
+
+		expect(response.status).toBe(409);
+		await expect(response.json()).resolves.toMatchObject({
+			code: "ALREADY_REJECTED",
+		});
+		expect(fake.insert).not.toHaveBeenCalled();
+	});
+
+	it("treats a lost race to another approval as idempotent", async () => {
+		const fake = createFakeTransaction();
+		fake.claimReturning.mockResolvedValue([]);
+		fake.statusWhere.mockResolvedValue([
+			{ status: SUBMISSION_STATUS.APPROVED },
+		]);
+		runTransactionWith(fake);
+
+		const response = await approveSubmission();
+
+		expect(response.status).toBe(200);
+		await expect(response.text()).resolves.toBe("Approved");
+		expect(fake.insert).not.toHaveBeenCalled();
+	});
+
+	it("returns 404 without publishing a nonexistent submission", async () => {
+		const fake = createFakeTransaction();
+		fake.claimReturning.mockResolvedValue([]);
+		fake.statusWhere.mockResolvedValue([]);
+		runTransactionWith(fake);
+
+		const response = await approveSubmission();
+
+		expect(response.status).toBe(404);
+		expect(fake.insert).not.toHaveBeenCalled();
+	});
+
+	it("lets publication failures escape the callback so the claim rolls back", async () => {
+		const fake = createFakeTransaction();
+		fake.claimReturning.mockResolvedValue([
+			{
+				id: 123,
+				msg: "A message",
+				hash: "hash",
+				slug: "a-message",
+				date: "2026-07-18",
+				clerkUserId: "submitter",
+				status: SUBMISSION_STATUS.APPROVED,
+				authorName: null,
+			},
+		]);
+		fake.messageReturning.mockRejectedValue(new Error("message insert failed"));
+		let rolledBack = false;
+		runTransactionWith(fake, () => {
+			rolledBack = true;
+		});
+
+		const response = await approveSubmission();
+
+		expect(response.status).toBe(500);
+		expect(rolledBack).toBe(true);
+		expect(fake.claimReturning.mock.invocationCallOrder[0]).toBeLessThan(
+			fake.insert.mock.invocationCallOrder[0],
+		);
+	});
+});

--- a/__tests__/components/ui/Toast.test.tsx
+++ b/__tests__/components/ui/Toast.test.tsx
@@ -130,7 +130,11 @@ describe("Toast Components", () => {
 		it("renders with destructive variant", () => {
 			render(
 				<ToastProvider>
-					<Toast open variant="destructive" data-testid="test-toast-destructive">
+					<Toast
+						open
+						variant="destructive"
+						data-testid="test-toast-destructive"
+					>
 						<div>Destructive toast</div>
 					</Toast>
 					<ToastViewport />
@@ -150,7 +154,11 @@ describe("Toast Components", () => {
 		it("applies custom className", () => {
 			render(
 				<ToastProvider>
-					<Toast open className="custom-toast-class" data-testid="test-toast-custom">
+					<Toast
+						open
+						className="custom-toast-class"
+						data-testid="test-toast-custom"
+					>
 						<div>Custom toast</div>
 					</Toast>
 					<ToastViewport />

--- a/__tests__/components/ui/Toaster.test.tsx
+++ b/__tests__/components/ui/Toaster.test.tsx
@@ -188,7 +188,9 @@ describe("Toaster", () => {
 
 		await waitFor(() => {
 			const toastItems = screen.getAllByRole("listitem");
-			const toast = toastItems.find((el) => el.textContent?.includes("Test Title"));
+			const toast = toastItems.find((el) =>
+				el.textContent?.includes("Test Title"),
+			);
 			const gridContainer = toast?.querySelector(".grid.gap-1");
 			expect(gridContainer).toBeInTheDocument();
 		});

--- a/__tests__/db/schema.test.ts
+++ b/__tests__/db/schema.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "@jest/globals";
+import * as schema from "@/db/schema";
+
+describe("schema relations", () => {
+	it("does not associate submissions with message-author rows", () => {
+		expect(schema).not.toHaveProperty("submissionsRelations");
+	});
+
+	it("retains the valid message and author relation metadata", () => {
+		expect(schema).toHaveProperty("messagesRelations");
+		expect(schema).toHaveProperty("authorsRelations");
+		expect(schema).toHaveProperty("messageAuthorsRelations");
+	});
+});

--- a/__tests__/lib/constants.test.ts
+++ b/__tests__/lib/constants.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+	getApprovalResult,
+	getRejectionResult,
+	getRejectionTransition,
+	SUBMISSION_STATUS,
+} from "@/lib/constants";
+
+describe("getApprovalResult", () => {
+	it("reports a successful atomic claim", () => {
+		expect(getApprovalResult(true)).toBe("approved");
+	});
+
+	it("distinguishes missing, idempotent, denied, and lost-race outcomes", () => {
+		expect(getApprovalResult(false)).toBe("not-found");
+		expect(getApprovalResult(false, SUBMISSION_STATUS.APPROVED)).toBe(
+			"already-approved",
+		);
+		expect(getApprovalResult(false, SUBMISSION_STATUS.DENIED)).toBe(
+			"already-rejected",
+		);
+		expect(getApprovalResult(false, SUBMISSION_STATUS.PENDING)).toBe(
+			"conflict",
+		);
+	});
+});
+
+describe("getRejectionTransition", () => {
+	it("allows pending submissions to be rejected", () => {
+		expect(getRejectionTransition(SUBMISSION_STATUS.PENDING)).toBe("reject");
+	});
+
+	it("treats already-rejected submissions as idempotent", () => {
+		expect(getRejectionTransition(SUBMISSION_STATUS.DENIED)).toBe(
+			"already-rejected",
+		);
+	});
+
+	it("rejects approved and unknown status transitions", () => {
+		expect(getRejectionTransition(SUBMISSION_STATUS.APPROVED)).toBe("conflict");
+		expect(getRejectionTransition(999)).toBe("conflict");
+	});
+});
+
+describe("getRejectionResult", () => {
+	it("reports a successful conditional update", () => {
+		expect(getRejectionResult(true)).toBe("rejected");
+	});
+
+	it("distinguishes missing, idempotent, and conflicting outcomes", () => {
+		expect(getRejectionResult(false)).toBe("not-found");
+		expect(getRejectionResult(false, SUBMISSION_STATUS.DENIED)).toBe(
+			"already-rejected",
+		);
+		expect(getRejectionResult(false, SUBMISSION_STATUS.APPROVED)).toBe(
+			"conflict",
+		);
+		expect(getRejectionResult(false, SUBMISSION_STATUS.PENDING)).toBe(
+			"conflict",
+		);
+	});
+});

--- a/__tests__/lib/env.test.ts
+++ b/__tests__/lib/env.test.ts
@@ -60,7 +60,10 @@ describe("Environment Variable Validation", () => {
 		process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_123";
 		process.env.CLERK_SECRET_KEY = "sk_test_123";
 		process.env.NEXT_PUBLIC_APP_URL = "https://example.com";
-		Object.defineProperty(process.env, "NODE_ENV", { value: "test", writable: true });
+		Object.defineProperty(process.env, "NODE_ENV", {
+			value: "test",
+			writable: true,
+		});
 
 		expect(() => {
 			jest.isolateModules(() => {
@@ -81,7 +84,10 @@ describe("Environment Variable Validation", () => {
 		process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_123";
 		process.env.CLERK_SECRET_KEY = "sk_test_123";
 		delete process.env.NEXT_PUBLIC_APP_URL;
-		Object.defineProperty(process.env, "NODE_ENV", { value: "test", writable: true });
+		Object.defineProperty(process.env, "NODE_ENV", {
+			value: "test",
+			writable: true,
+		});
 
 		expect(() => {
 			jest.isolateModules(() => {

--- a/__tests__/lib/message-fetch.test.ts
+++ b/__tests__/lib/message-fetch.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+	classifyMessageResponse,
+	MessageFetchError,
+} from "@/lib/message-fetch";
+
+describe("classifyMessageResponse", () => {
+	it("classifies only 404 as missing content", () => {
+		expect(
+			classifyMessageResponse({
+				ok: false,
+				status: 404,
+				statusText: "Not Found",
+			}),
+		).toBe("not-found");
+	});
+
+	it.each([429, 500, 503])("throws for non-404 error status %i", (status) => {
+		expect(() =>
+			classifyMessageResponse({ ok: false, status, statusText: "Failure" }),
+		).toThrow(MessageFetchError);
+	});
+
+	it("classifies successful responses as found", () => {
+		expect(
+			classifyMessageResponse({ ok: true, status: 200, statusText: "OK" }),
+		).toBe("found");
+	});
+});

--- a/__tests__/lib/rate-limit.test.ts
+++ b/__tests__/lib/rate-limit.test.ts
@@ -1,4 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach, jest } from "@jest/globals";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	jest,
+} from "@jest/globals";
 
 // Mock Next.js modules before importing rate-limit
 jest.mock("next/headers", () => ({
@@ -8,7 +15,10 @@ jest.mock("next/headers", () => ({
 jest.mock("next/server", () => ({
 	NextResponse: {
 		json: jest.fn(
-			(body: unknown, init?: { status?: number; headers?: Record<string, string> }) => ({
+			(
+				body: unknown,
+				init?: { status?: number; headers?: Record<string, string> },
+			) => ({
 				body,
 				status: init?.status || 200,
 				headers: {
@@ -59,52 +69,63 @@ describe("rate-limit", () => {
 		});
 
 		it("falls back to x-real-ip when x-forwarded-for is absent", async () => {
-			jest.mocked(headers).mockResolvedValue(
-				new Map([["x-real-ip", "203.0.113.7"]]) as unknown as Awaited<
-					ReturnType<typeof headers>
-				>,
-			);
+			jest
+				.mocked(headers)
+				.mockResolvedValue(
+					new Map([["x-real-ip", "203.0.113.7"]]) as unknown as Awaited<
+						ReturnType<typeof headers>
+					>,
+				);
 			const ip = await getClientIP();
 			expect(ip).toBe("203.0.113.7");
 		});
 
 		it("returns 'unknown' when no headers are present", async () => {
-			jest.mocked(headers).mockResolvedValue(
-				new Map() as unknown as Awaited<ReturnType<typeof headers>>,
-			);
+			jest
+				.mocked(headers)
+				.mockResolvedValue(
+					new Map() as unknown as Awaited<ReturnType<typeof headers>>,
+				);
 			const ip = await getClientIP();
 			expect(ip).toBe("unknown");
 		});
 
 		it("underflows to leftmost for a single XFF entry with TRUSTED_PROXY_HOPS=1", async () => {
 			process.env.TRUSTED_PROXY_HOPS = "1";
-			jest.mocked(headers).mockResolvedValue(
-				new Map([["x-forwarded-for", "1.2.3.4"]]) as unknown as Awaited<
-					ReturnType<typeof headers>
-				>,
-			);
+			jest
+				.mocked(headers)
+				.mockResolvedValue(
+					new Map([["x-forwarded-for", "1.2.3.4"]]) as unknown as Awaited<
+						ReturnType<typeof headers>
+					>,
+				);
 			const ip = await getClientIP();
 			expect(ip).toBe("1.2.3.4");
 		});
 
-		it("returns the single entry with TRUSTED_PROXY_HOPS=0", async () => {
+		it("ignores XFF with TRUSTED_PROXY_HOPS=0", async () => {
 			process.env.TRUSTED_PROXY_HOPS = "0";
-			jest.mocked(headers).mockResolvedValue(
-				new Map([["x-forwarded-for", "1.2.3.4"]]) as unknown as Awaited<
-					ReturnType<typeof headers>
-				>,
-			);
+			jest
+				.mocked(headers)
+				.mockResolvedValue(
+					new Map([["x-forwarded-for", "1.2.3.4"]]) as unknown as Awaited<
+						ReturnType<typeof headers>
+					>,
+				);
 			const ip = await getClientIP();
-			expect(ip).toBe("1.2.3.4");
+			expect(ip).toBe("unknown");
+			expect(headers).not.toHaveBeenCalled();
 		});
 
 		it("returns the rightmost (Railway-recorded) entry for two XFF entries with TRUSTED_PROXY_HOPS=1", async () => {
 			process.env.TRUSTED_PROXY_HOPS = "1";
-			jest.mocked(headers).mockResolvedValue(
-				new Map([["x-forwarded-for", "1.2.3.4, 5.6.7.8"]]) as unknown as Awaited<
-					ReturnType<typeof headers>
-				>,
-			);
+			jest
+				.mocked(headers)
+				.mockResolvedValue(
+					new Map([
+						["x-forwarded-for", "1.2.3.4, 5.6.7.8"],
+					]) as unknown as Awaited<ReturnType<typeof headers>>,
+				);
 			const ip = await getClientIP();
 			expect(ip).toBe("5.6.7.8");
 		});
@@ -112,11 +133,13 @@ describe("rate-limit", () => {
 		it("ignores a client-spoofed leading XFF entry (rate-limit anti-bypass)", async () => {
 			// Attacker sends "9.9.9.9"; Railway appends the real socket IP on the
 			// right. With one trusted hop we must key on the real IP, not the spoof.
-			jest.mocked(headers).mockResolvedValue(
-				new Map([
-					["x-forwarded-for", "9.9.9.9, 203.0.113.5"],
-				]) as unknown as Awaited<ReturnType<typeof headers>>,
-			);
+			jest
+				.mocked(headers)
+				.mockResolvedValue(
+					new Map([
+						["x-forwarded-for", "9.9.9.9, 203.0.113.5"],
+					]) as unknown as Awaited<ReturnType<typeof headers>>,
+				);
 			const ip = await getClientIP();
 			expect(ip).toBe("203.0.113.5");
 		});
@@ -124,65 +147,77 @@ describe("rate-limit", () => {
 		it("selects the client entry behind two trusted hops (Cloudflare→Railway)", async () => {
 			process.env.TRUSTED_PROXY_HOPS = "2";
 			// spoof, real client (added by CF), CF ip (added by Railway)
-			jest.mocked(headers).mockResolvedValue(
-				new Map([
-					["x-forwarded-for", "9.9.9.9, 203.0.113.5, 10.0.0.1"],
-				]) as unknown as Awaited<ReturnType<typeof headers>>,
-			);
+			jest
+				.mocked(headers)
+				.mockResolvedValue(
+					new Map([
+						["x-forwarded-for", "9.9.9.9, 203.0.113.5, 10.0.0.1"],
+					]) as unknown as Awaited<ReturnType<typeof headers>>,
+				);
 			const ip = await getClientIP();
 			expect(ip).toBe("203.0.113.5");
 		});
 
 		it("returns the leftmost entry for two XFF entries with TRUSTED_PROXY_HOPS=2", async () => {
 			process.env.TRUSTED_PROXY_HOPS = "2";
-			jest.mocked(headers).mockResolvedValue(
-				new Map([["x-forwarded-for", "1.2.3.4, 5.6.7.8"]]) as unknown as Awaited<
-					ReturnType<typeof headers>
-				>,
-			);
+			jest
+				.mocked(headers)
+				.mockResolvedValue(
+					new Map([
+						["x-forwarded-for", "1.2.3.4, 5.6.7.8"],
+					]) as unknown as Awaited<ReturnType<typeof headers>>,
+				);
 			const ip = await getClientIP();
 			expect(ip).toBe("1.2.3.4");
 		});
 
 		it("trims extra whitespace in malformed XFF entries", async () => {
 			process.env.TRUSTED_PROXY_HOPS = "1";
-			jest.mocked(headers).mockResolvedValue(
-				new Map([["x-forwarded-for", " 1.2.3.4 , 5.6.7.8 "]]) as unknown as Awaited<
-					ReturnType<typeof headers>
-				>,
-			);
+			jest
+				.mocked(headers)
+				.mockResolvedValue(
+					new Map([
+						["x-forwarded-for", " 1.2.3.4 , 5.6.7.8 "],
+					]) as unknown as Awaited<ReturnType<typeof headers>>,
+				);
 			const ip = await getClientIP();
 			expect(ip).toBe("5.6.7.8");
 		});
 
 		it("defaults to 1 hop when TRUSTED_PROXY_HOPS is not set", async () => {
-			jest.mocked(headers).mockResolvedValue(
-				new Map([["x-forwarded-for", "1.2.3.4, 5.6.7.8"]]) as unknown as Awaited<
-					ReturnType<typeof headers>
-				>,
-			);
+			jest
+				.mocked(headers)
+				.mockResolvedValue(
+					new Map([
+						["x-forwarded-for", "1.2.3.4, 5.6.7.8"],
+					]) as unknown as Awaited<ReturnType<typeof headers>>,
+				);
 			const ip = await getClientIP();
 			expect(ip).toBe("5.6.7.8");
 		});
 
-		it("uses 0 when TRUSTED_PROXY_HOPS=0 (critical case)", async () => {
+		it("does not trust spoofed forwarding headers with TRUSTED_PROXY_HOPS=0", async () => {
 			process.env.TRUSTED_PROXY_HOPS = "0";
 			jest.mocked(headers).mockResolvedValue(
-				new Map([["x-forwarded-for", "1.2.3.4, 5.6.7.8"]]) as unknown as Awaited<
-					ReturnType<typeof headers>
-				>,
+				new Map([
+					["x-forwarded-for", "1.2.3.4, 5.6.7.8"],
+					["x-real-ip", "9.9.9.9"],
+				]) as unknown as Awaited<ReturnType<typeof headers>>,
 			);
 			const ip = await getClientIP();
-			expect(ip).toBe("5.6.7.8");
+			expect(ip).toBe("unknown");
+			expect(headers).not.toHaveBeenCalled();
 		});
 
 		it("falls back to 1 when TRUSTED_PROXY_HOPS is invalid", async () => {
 			process.env.TRUSTED_PROXY_HOPS = "invalid";
-			jest.mocked(headers).mockResolvedValue(
-				new Map([["x-forwarded-for", "1.2.3.4, 5.6.7.8"]]) as unknown as Awaited<
-					ReturnType<typeof headers>
-				>,
-			);
+			jest
+				.mocked(headers)
+				.mockResolvedValue(
+					new Map([
+						["x-forwarded-for", "1.2.3.4, 5.6.7.8"],
+					]) as unknown as Awaited<ReturnType<typeof headers>>,
+				);
 			const ip = await getClientIP();
 			expect(ip).toBe("5.6.7.8");
 		});
@@ -190,7 +225,7 @@ describe("rate-limit", () => {
 
 	describe("checkRateLimit", () => {
 		it("should allow requests within the limit", () => {
-			const options = { limit: 5, windowMs: 60000 };
+			const options = { policy: "allow-test", limit: 5, windowMs: 60000 };
 
 			// First 5 requests should be allowed
 			for (let i = 0; i < 5; i++) {
@@ -201,7 +236,7 @@ describe("rate-limit", () => {
 		});
 
 		it("should block requests exceeding the limit", () => {
-			const options = { limit: 3, windowMs: 60000 };
+			const options = { policy: "block-test", limit: 3, windowMs: 60000 };
 
 			// Use up the limit
 			for (let i = 0; i < 3; i++) {
@@ -215,7 +250,7 @@ describe("rate-limit", () => {
 		});
 
 		it("should track different IPs separately", () => {
-			const options = { limit: 2, windowMs: 60000 };
+			const options = { policy: "ip-test", limit: 2, windowMs: 60000 };
 
 			// Use up limit for IP 1
 			checkRateLimit("ip-1", options);
@@ -230,17 +265,21 @@ describe("rate-limit", () => {
 		});
 
 		it("should provide correct resetAt timestamp", () => {
-			const options = { limit: 5, windowMs: 60000 };
+			const options = { policy: "reset-test", limit: 5, windowMs: 60000 };
 			const beforeTime = Date.now();
 
 			const result = checkRateLimit("test-ip-reset", options);
 
-			expect(result.resetAt).toBeGreaterThanOrEqual(beforeTime + options.windowMs);
-			expect(result.resetAt).toBeLessThanOrEqual(Date.now() + options.windowMs + 10);
+			expect(result.resetAt).toBeGreaterThanOrEqual(
+				beforeTime + options.windowMs,
+			);
+			expect(result.resetAt).toBeLessThanOrEqual(
+				Date.now() + options.windowMs + 10,
+			);
 		});
 
 		it("should correctly calculate remaining requests", () => {
-			const options = { limit: 10, windowMs: 60000 };
+			const options = { policy: "remaining-test", limit: 10, windowMs: 60000 };
 
 			const result1 = checkRateLimit("test-ip-remaining", options);
 			expect(result1.remaining).toBe(9);
@@ -250,6 +289,27 @@ describe("rate-limit", () => {
 
 			const result3 = checkRateLimit("test-ip-remaining", options);
 			expect(result3.remaining).toBe(7);
+		});
+
+		it("should isolate counters for different policies on the same IP", () => {
+			const publicOptions = {
+				policy: "public-test",
+				limit: 2,
+				windowMs: 60000,
+			};
+			const adminOptions = {
+				policy: "admin-test",
+				limit: 2,
+				windowMs: 60000,
+			};
+
+			expect(checkRateLimit("shared-ip", publicOptions).remaining).toBe(1);
+			expect(checkRateLimit("shared-ip", publicOptions).remaining).toBe(0);
+			expect(checkRateLimit("shared-ip", publicOptions).allowed).toBe(false);
+
+			expect(checkRateLimit("shared-ip", adminOptions).remaining).toBe(1);
+			expect(checkRateLimit("shared-ip", adminOptions).remaining).toBe(0);
+			expect(checkRateLimit("shared-ip", adminOptions).allowed).toBe(false);
 		});
 	});
 
@@ -277,7 +337,7 @@ describe("rate-limit", () => {
 
 	describe("clearRateLimitStore", () => {
 		it("should clear all entries from the store", () => {
-			const options = { limit: 10, windowMs: 60000 };
+			const options = { policy: "clear-test", limit: 10, windowMs: 60000 };
 
 			// Add some entries
 			checkRateLimit("ip-a", options);
@@ -294,7 +354,7 @@ describe("rate-limit", () => {
 
 	describe("getRateLimitStoreSize", () => {
 		it("should return correct count of entries", () => {
-			const options = { limit: 10, windowMs: 60000 };
+			const options = { policy: "size-test", limit: 10, windowMs: 60000 };
 
 			expect(getRateLimitStoreSize()).toBe(0);
 

--- a/__tests__/lib/sitemap-date.test.ts
+++ b/__tests__/lib/sitemap-date.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+	parseSitemapDate,
+	resolveSitemapLastModified,
+} from "@/lib/sitemap-date";
+
+describe("parseSitemapDate", () => {
+	it("accepts Date and ISO/date strings", () => {
+		const date = new Date("2026-07-18T12:34:56.000Z");
+		expect(parseSitemapDate(date)).toEqual(date);
+		expect(parseSitemapDate("2026-07-18T12:34:56.000Z")).toEqual(date);
+		expect(parseSitemapDate("2026-07-18")).toEqual(
+			new Date("2026-07-18T00:00:00.000Z"),
+		);
+	});
+
+	it("accepts valid leap days", () => {
+		expect(parseSitemapDate("2024-02-29")).toEqual(
+			new Date("2024-02-29T00:00:00.000Z"),
+		);
+		expect(parseSitemapDate("2000-02-29T12:00:00.000Z")).toEqual(
+			new Date("2000-02-29T12:00:00.000Z"),
+		);
+	});
+
+	it.each([
+		"2026-02-29",
+		"2026-02-30",
+		"2026-02-30T12:00:00.000Z",
+		"2026-04-31",
+		"2026-13-01",
+	])("rejects impossible ISO calendar date %s", (value) => {
+		expect(parseSitemapDate(value)).toBeUndefined();
+	});
+
+	it("accepts numeric epoch seconds and milliseconds", () => {
+		const expected = new Date("2026-07-18T12:34:56.000Z");
+		const seconds = expected.getTime() / 1000;
+		const milliseconds = expected.getTime();
+
+		expect(parseSitemapDate(seconds)).toEqual(expected);
+		expect(parseSitemapDate(String(seconds))).toEqual(expected);
+		expect(parseSitemapDate(milliseconds)).toEqual(expected);
+		expect(parseSitemapDate(String(milliseconds))).toEqual(expected);
+	});
+
+	it("returns undefined for invalid or missing values", () => {
+		expect(parseSitemapDate(undefined)).toBeUndefined();
+		expect(parseSitemapDate(null)).toBeUndefined();
+		expect(parseSitemapDate("")).toBeUndefined();
+		expect(parseSitemapDate("not-a-date")).toBeUndefined();
+		expect(parseSitemapDate("02/30/2026")).toBeUndefined();
+		expect(parseSitemapDate(new Date(Number.NaN))).toBeUndefined();
+	});
+});
+
+describe("resolveSitemapLastModified", () => {
+	it("prefers approval date and falls back to the original date", () => {
+		expect(resolveSitemapLastModified("2026-07-18", "2025-01-01")).toEqual(
+			new Date("2026-07-18T00:00:00.000Z"),
+		);
+		expect(resolveSitemapLastModified("invalid", "2025-01-01")).toEqual(
+			new Date("2025-01-01T00:00:00.000Z"),
+		);
+	});
+
+	it("uses stable omission when neither date is valid", () => {
+		expect(resolveSitemapLastModified(null, "invalid")).toBeUndefined();
+	});
+});

--- a/__tests__/lib/tokens.test.ts
+++ b/__tests__/lib/tokens.test.ts
@@ -1,9 +1,5 @@
-import { describe, it, expect } from "@jest/globals";
-import {
-	generateAPIToken,
-	hashToken,
-	verifyApiToken,
-} from "@/lib/tokens";
+import { describe, expect, it } from "@jest/globals";
+import { generateAPIToken, hashToken, verifyApiToken } from "@/lib/tokens";
 
 describe("tokens", () => {
 	describe("generateAPIToken", () => {

--- a/__tests__/utils/sanitize.test.ts
+++ b/__tests__/utils/sanitize.test.ts
@@ -91,7 +91,9 @@ describe("sanitizeContent", () => {
 		it("should not provide injection protection (DB access is parameterized)", () => {
 			// Words are preserved; only the non-word "*" is stripped as a special char
 			expect(sanitizeContent("SELECT * FROM users")).toBe("SELECT FROM users");
-			expect(sanitizeContent("DROP TABLE students")).toBe("DROP TABLE students");
+			expect(sanitizeContent("DROP TABLE students")).toBe(
+				"DROP TABLE students",
+			);
 		});
 	});
 

--- a/__tests__/utils/text.test.ts
+++ b/__tests__/utils/text.test.ts
@@ -65,12 +65,37 @@ describe("generateSlug", () => {
 
 	describe("Special Character Handling", () => {
 		it("should transliterate accented characters", () => {
-			expect(generateSlug("Héllo Wørld")).toBe(
-				"5b2fa713c25cd166e41f3acd508dde86",
-			);
-			expect(generateSlug("über straße")).toBe(
-				"e71b89e76622ae8eea516dc0999e9785",
-			);
+			const cases = [
+				["Héllo Wørld", "hello-world"],
+				["über straße", "uber-strasse"],
+				["Ærøskøbing Œuvre Škoda", "aeroskobing-oeuvre-skoda"],
+			] as const;
+
+			for (const [input, readableSlug] of cases) {
+				expect(generateSlug(input)).toBe(
+					`${readableSlug}-${generateMD5(input).slice(0, 8)}`,
+				);
+			}
+		});
+
+		it.each([
+			["Héllo Wørld", "Hello World"],
+			["straße", "strasse"],
+		])(
+			"disambiguates transliterated %s from ASCII-equivalent %s",
+			(accented, ascii) => {
+				const accentedSlug = generateSlug(accented);
+				const asciiSlug = generateSlug(ascii);
+
+				expect(accentedSlug).not.toBe(asciiSlug);
+				expect(accentedSlug).toBe(
+					`${asciiSlug}-${generateMD5(accented).slice(0, 8)}`,
+				);
+			},
+		);
+
+		it("uses an explicit content hash for the transliteration suffix", () => {
+			expect(generateSlug("café", "abcdef1234567890")).toBe("cafe-abcdef12");
 		});
 
 		it("should use hash for non-transliterable special characters", () => {
@@ -100,15 +125,17 @@ describe("generateSlug", () => {
 		it("should handle combination of spaces, hyphens, and special characters (from charMap)", () => {
 			expect(generateSlug("  -Héllo---wørld!  ")).toBe(
 				"5d09492d4c5826758d27211b9fc71402",
-			); // '!' is removed
+			); // Unsupported punctuation preserves the hash fallback.
 		});
 
 		it("should handle long string of characters mapped by charMap, then truncated", () => {
 			const longSpecial = "é".repeat(60); // 'é' maps to 'e'
 
-			expect(generateSlug(longSpecial)).toBe(
-				"45698e682c350ba8a3844fb8efbab899",
+			const slug = generateSlug(longSpecial);
+			expect(slug).toBe(
+				`${"e".repeat(41)}-${generateMD5(longSpecial).slice(0, 8)}`,
 			);
+			expect(slug).toHaveLength(50);
 		});
 
 		it("should handle a long string of characters", () => {
@@ -188,14 +215,16 @@ describe("generateSlug with non-Latin handling", () => {
 		expect(generateSlug(text, hash)).toBe(hash);
 	});
 
-	it("should return hash for non-Latin text", () => {
+	it("should transliterate supported accented Latin text", () => {
 		const text1 = "Héllo World";
-		const expectedHash1 = generateMD5(text1);
-		expect(generateSlug(text1)).toBe(expectedHash1);
+		expect(generateSlug(text1)).toBe(
+			`hello-world-${generateMD5(text1).slice(0, 8)}`,
+		);
 
 		const text2 = "über straße";
-		const expectedHash2 = generateMD5(text2);
-		expect(generateSlug(text2)).toBe(expectedHash2);
+		expect(generateSlug(text2)).toBe(
+			`uber-strasse-${generateMD5(text2).slice(0, 8)}`,
+		);
 	});
 });
 

--- a/app/add/page.tsx
+++ b/app/add/page.tsx
@@ -4,7 +4,7 @@ import { generateSEOMetadata } from "@/lib/seo";
 import { AddMessageForm } from "./add-message-form";
 
 // Force dynamic rendering - this page requires authentication
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
 // Metadata for the add message page
 export const metadata = generateSEOMetadata({

--- a/app/admin/admin-submissions-table.tsx
+++ b/app/admin/admin-submissions-table.tsx
@@ -165,20 +165,22 @@ export function AdminSubmissionsTable({
 						<Button
 							variant="ghost"
 							size="icon"
+							aria-label={`Approve submission ${submission.id}`}
 							onClick={() => handleApprove(submission.id)}
 							disabled={isProcessing}
 							className="hover:text-green-600"
 						>
-							<ThumbsUp className="h-4 w-4" />
+							<ThumbsUp className="h-4 w-4" aria-hidden="true" />
 						</Button>
 						<Button
 							variant="ghost"
 							size="icon"
+							aria-label={`Reject submission ${submission.id}`}
 							onClick={() => handleReject(submission.id)}
 							disabled={isProcessing}
 							className="hover:text-red-600"
 						>
-							<ThumbsDown className="h-4 w-4" />
+							<ThumbsDown className="h-4 w-4" aria-hidden="true" />
 						</Button>
 					</div>
 				);

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -9,7 +9,7 @@ import logger from "@/lib/logger";
 import { AdminSubmissionsTable } from "./admin-submissions-table";
 
 // Force dynamic rendering - this page requires authentication and database
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
 export default async function AdminPage() {
 	const user = await currentUser();

--- a/app/api/admin/submissions/[id]/approve/route.ts
+++ b/app/api/admin/submissions/[id]/approve/route.ts
@@ -1,10 +1,10 @@
 import { currentUser } from "@clerk/nextjs/server";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 import { db } from "@/db/client";
 import { authors, message_authors, messages, submissions } from "@/db/schema";
 import { isUserAdmin } from "@/lib/auth";
-import { SUBMISSION_STATUS } from "@/lib/constants";
+import { getApprovalResult, SUBMISSION_STATUS } from "@/lib/constants";
 import { APIError, handleAPIError } from "@/lib/error-handler";
 import logger from "@/lib/logger";
 import { applyRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
@@ -45,30 +45,29 @@ export async function POST(
 			throw new APIError("Admin access required", 403, "ADMIN_REQUIRED");
 		}
 
-		// Get the submission
-		const [submission] = await db
-			.select()
-			.from(submissions)
-			.where(eq(submissions.id, submissionId));
+		const approvalResult = await db.transaction(async (tx) => {
+			// Claim the submission before publishing it. Only one concurrent approval
+			// or rejection can transition the pending row.
+			const [submission] = await tx
+				.update(submissions)
+				.set({ status: SUBMISSION_STATUS.APPROVED })
+				.where(
+					and(
+						eq(submissions.id, submissionId),
+						eq(submissions.status, SUBMISSION_STATUS.PENDING),
+					),
+				)
+				.returning();
 
-		if (!submission) {
-			logger.warn("Submission not found for approval", { submissionId });
-			throw new APIError("Submission not found", 404, "NOT_FOUND");
-		}
+			if (!submission) {
+				const [currentSubmission] = await tx
+					.select({ status: submissions.status })
+					.from(submissions)
+					.where(eq(submissions.id, submissionId));
 
-		if (submission.status === SUBMISSION_STATUS.APPROVED) {
-			logger.warn("Attempt to approve already approved submission", {
-				submissionId,
-			});
-			throw new APIError(
-				"Submission already approved",
-				400,
-				"ALREADY_APPROVED",
-			);
-		}
+				return getApprovalResult(false, currentSubmission?.status);
+			}
 
-		// Start a transaction
-		await db.transaction(async (tx) => {
 			// Insert into messages
 			const [insertedMessage] = await tx
 				.insert(messages)
@@ -111,12 +110,43 @@ export async function POST(
 				}
 			}
 
-			// Update submission status
-			await tx
-				.update(submissions)
-				.set({ status: SUBMISSION_STATUS.APPROVED })
-				.where(eq(submissions.id, submissionId));
+			return getApprovalResult(true);
 		});
+
+		if (approvalResult === "not-found") {
+			logger.warn("Submission not found for approval", { submissionId });
+			throw new APIError("Submission not found", 404, "NOT_FOUND");
+		}
+
+		if (approvalResult === "already-approved") {
+			logger.info(
+				"Submission already approved; treating request as idempotent",
+				{ submissionId },
+			);
+			return new NextResponse("Approved", { status: 200 });
+		}
+
+		if (approvalResult === "already-rejected") {
+			logger.warn("Attempt to approve submission from invalid status", {
+				submissionId,
+			});
+			throw new APIError(
+				"Submission already rejected",
+				409,
+				"ALREADY_REJECTED",
+			);
+		}
+
+		if (approvalResult === "conflict") {
+			logger.warn("Approval claim lost without a terminal status", {
+				submissionId,
+			});
+			throw new APIError(
+				"Submission approval conflicted with another request",
+				409,
+				"INVALID_STATUS_TRANSITION",
+			);
+		}
 
 		logger.info("Submission approved successfully", {
 			submissionId,

--- a/app/api/admin/submissions/[id]/reject/route.ts
+++ b/app/api/admin/submissions/[id]/reject/route.ts
@@ -1,10 +1,10 @@
 import { currentUser } from "@clerk/nextjs/server";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/db/client";
 import { submissions } from "@/db/schema";
 import { isUserAdmin } from "@/lib/auth";
-import { SUBMISSION_STATUS } from "@/lib/constants";
+import { getRejectionResult, SUBMISSION_STATUS } from "@/lib/constants";
 import { APIError, handleAPIError } from "@/lib/error-handler";
 import logger from "@/lib/logger";
 import { applyRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
@@ -41,33 +41,62 @@ export async function POST(
 			throw new APIError("Admin access required", 403, "ADMIN_REQUIRED");
 		}
 
-		// Check if submission exists and isn't already rejected
-		const [submission] = await db
-			.select()
-			.from(submissions)
-			.where(eq(submissions.id, submissionId));
+		// Atomically transition only pending submissions. Matching the prior status
+		// prevents a concurrent approval from being overwritten after publishing.
+		const [rejectedSubmission] = await db
+			.update(submissions)
+			.set({ status: SUBMISSION_STATUS.DENIED })
+			.where(
+				and(
+					eq(submissions.id, submissionId),
+					eq(submissions.status, SUBMISSION_STATUS.PENDING),
+				),
+			)
+			.returning({ id: submissions.id });
 
-		if (!submission) {
+		let currentStatus: number | undefined;
+		if (!rejectedSubmission) {
+			const [submission] = await db
+				.select({ status: submissions.status })
+				.from(submissions)
+				.where(eq(submissions.id, submissionId));
+			currentStatus = submission?.status;
+		}
+
+		const result = getRejectionResult(
+			Boolean(rejectedSubmission),
+			currentStatus,
+		);
+
+		if (result === "not-found") {
 			logger.warn("Submission not found for rejection", { submissionId });
 			throw new APIError("Submission not found", 404, "NOT_FOUND");
 		}
 
-		if (submission.status === SUBMISSION_STATUS.DENIED) {
-			logger.warn("Attempt to reject already rejected submission", {
-				submissionId,
-			});
-			throw new APIError(
-				"Submission already rejected",
-				400,
-				"ALREADY_REJECTED",
+		if (result === "already-rejected") {
+			logger.info(
+				"Submission already rejected; treating request as idempotent",
+				{
+					submissionId,
+				},
 			);
+			return new NextResponse("Rejected", { status: 200 });
 		}
 
-		// Update submission status
-		const _result = await db
-			.update(submissions)
-			.set({ status: SUBMISSION_STATUS.DENIED })
-			.where(eq(submissions.id, submissionId));
+		if (result === "conflict") {
+			logger.warn("Attempt to reject submission from invalid status", {
+				submissionId,
+				status: currentStatus,
+			});
+			const isApproved = currentStatus === SUBMISSION_STATUS.APPROVED;
+			throw new APIError(
+				isApproved
+					? "Submission already approved"
+					: "Submission cannot be rejected from its current status",
+				409,
+				isApproved ? "ALREADY_APPROVED" : "INVALID_STATUS_TRANSITION",
+			);
+		}
 
 		logger.info("Submission rejected successfully", {
 			submissionId,

--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -2,15 +2,12 @@ import { auth, currentUser } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 import { isUserAdmin } from "@/lib/auth";
 import { getOrCreateAuthor } from "@/lib/authors";
-import client from "@/lib/db";
 import { CACHE_MAX_AGE_SECONDS } from "@/lib/constants";
+import client from "@/lib/db";
 import { APIError, handleAPIError } from "@/lib/error-handler";
 import logger from "@/lib/logger";
 import { getMessages } from "@/lib/messages";
-import {
-	applyRateLimit,
-	RATE_LIMITS,
-} from "@/lib/rate-limit";
+import { applyRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
 import {
 	messageSchemas,
 	validateBody,
@@ -67,7 +64,9 @@ export async function GET(request: Request) {
 export async function POST(request: Request) {
 	try {
 		// Apply rate limiting for authenticated write endpoint
-		const rateLimitResponse = await applyRateLimit(RATE_LIMITS.AUTHENTICATED_WRITE);
+		const rateLimitResponse = await applyRateLimit(
+			RATE_LIMITS.AUTHENTICATED_WRITE,
+		);
 		if (rateLimitResponse) return rateLimitResponse;
 
 		// Validate request body using Zod

--- a/app/api/tokens/route.ts
+++ b/app/api/tokens/route.ts
@@ -15,7 +15,9 @@ import { generateAPIToken, hashToken } from "@/lib/tokens";
 export async function GET() {
 	try {
 		// Apply rate limiting for authenticated read endpoint
-		const rateLimitResponse = await applyRateLimit(RATE_LIMITS.AUTHENTICATED_WRITE);
+		const rateLimitResponse = await applyRateLimit(
+			RATE_LIMITS.AUTHENTICATED_WRITE,
+		);
 		if (rateLimitResponse) return rateLimitResponse;
 
 		const user = await currentUser();

--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -1,36 +1,34 @@
-import { ImageResponse } from 'next/og'
+import { ImageResponse } from "next/og";
 
-export const runtime = 'edge'
+export const runtime = "edge";
 
 export const size = {
-  width: 180,
-  height: 180,
-}
+	width: 180,
+	height: 180,
+};
 
-export const contentType = 'image/png'
+export const contentType = "image/png";
 
 export default function AppleIcon() {
-  return new ImageResponse(
-    (
-      <div
-        style={{
-          fontSize: 120,
-          background: '#A8D8F0',
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: 'white',
-          fontWeight: 'bold',
-          fontFamily: 'sans-serif',
-        }}
-      >
-        P
-      </div>
-    ),
-    {
-      ...size,
-    }
-  )
+	return new ImageResponse(
+		<div
+			style={{
+				fontSize: 120,
+				background: "#A8D8F0",
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				color: "white",
+				fontWeight: "bold",
+				fontFamily: "sans-serif",
+			}}
+		>
+			P
+		</div>,
+		{
+			...size,
+		},
+	);
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "tw-animate-css";
 
 @layer base {
 	body {

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -1,36 +1,34 @@
-import { ImageResponse } from 'next/og'
+import { ImageResponse } from "next/og";
 
-export const runtime = 'edge'
+export const runtime = "edge";
 
 export const size = {
-  width: 32,
-  height: 32,
-}
+	width: 32,
+	height: 32,
+};
 
-export const contentType = 'image/png'
+export const contentType = "image/png";
 
 export default function Icon() {
-  return new ImageResponse(
-    (
-      <div
-        style={{
-          fontSize: 24,
-          background: '#A8D8F0',
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: 'white',
-          fontWeight: 'bold',
-          fontFamily: 'sans-serif',
-        }}
-      >
-        P
-      </div>
-    ),
-    {
-      ...size,
-    }
-  )
+	return new ImageResponse(
+		<div
+			style={{
+				fontSize: 24,
+				background: "#A8D8F0",
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				color: "white",
+				fontWeight: "bold",
+				fontFamily: "sans-serif",
+			}}
+		>
+			P
+		</div>,
+		{
+			...size,
+		},
+	);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import { ClerkProvider } from "@clerk/nextjs";
-import type React from "react";
 import type { Viewport } from "next";
+import type React from "react";
 import "./globals.css";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Navigation } from "@/components/Navigation";

--- a/app/msg/[slug]/page.tsx
+++ b/app/msg/[slug]/page.tsx
@@ -1,10 +1,11 @@
 // page component
 
 import type { Metadata } from "next";
-import { cache } from "react";
 import { notFound } from "next/navigation";
+import { cache } from "react";
 import type { Message } from "@/app/api/messages/[slug]/route";
 import logger from "@/lib/logger";
+import { classifyMessageResponse } from "@/lib/message-fetch";
 import {
 	cleanTextForMeta,
 	generateMessageDescription,
@@ -37,37 +38,43 @@ type MessageWithNavigation = Message & {
 // Cached fetch function to deduplicate requests between generateMetadata and page component
 const fetchMessage = cache(
 	async (slug: string): Promise<MessageWithNavigation | null> => {
-		try {
-			const absoluteUrl = `${process.env.NEXT_PUBLIC_APP_URL}/api/messages/${slug}`;
-			logger.info(`Fetching message for slug: ${slug}`);
+		const absoluteUrl = `${process.env.NEXT_PUBLIC_APP_URL}/api/messages/${slug}`;
+		logger.info(`Fetching message for slug: ${slug}`);
 
-			const response = await fetch(absoluteUrl, {
+		let response: Response;
+		try {
+			response = await fetch(absoluteUrl, {
 				method: "GET",
 				headers: {
 					"Content-Type": "application/json",
 				},
 				cache: "no-store",
 			});
-
-			if (!response.ok) {
-				if (response.status === 404) {
-					return null;
-				}
-				logger.error("API request failed", {
-					status: response.status,
-					statusText: response.statusText,
-					url: absoluteUrl,
-				});
-				return null;
-			}
-
-			const message = (await response.json()) as MessageWithNavigation;
-			logger.info(`Successfully fetched message`, { messageId: message.id });
-			return message;
 		} catch (error) {
 			logger.error("Error fetching message:", { error, slug });
+			throw error;
+		}
+
+		if (!response.ok && response.status !== 404) {
+			logger.error("API request failed", {
+				status: response.status,
+				statusText: response.statusText,
+				url: absoluteUrl,
+			});
+		}
+		if (classifyMessageResponse(response) === "not-found") {
 			return null;
 		}
+
+		let message: MessageWithNavigation;
+		try {
+			message = (await response.json()) as MessageWithNavigation;
+		} catch (error) {
+			logger.error("Error parsing message response", { slug });
+			throw error;
+		}
+		logger.info(`Successfully fetched message`, { messageId: message.id });
+		return message;
 	},
 );
 

--- a/app/og/[slug]/route.tsx
+++ b/app/og/[slug]/route.tsx
@@ -129,7 +129,12 @@ export async function GET(
 				>
 					<div
 						style={{
-							fontSize: messageText.length > 100 ? 48 : messageText.length > 50 ? 56 : 72,
+							fontSize:
+								messageText.length > 100
+									? 48
+									: messageText.length > 50
+										? 56
+										: 72,
 							fontWeight: 500,
 							textAlign: "center",
 							lineHeight: 1.2,

--- a/app/settings/api-keys/_components/api-keys-manager.tsx
+++ b/app/settings/api-keys/_components/api-keys-manager.tsx
@@ -81,7 +81,8 @@ export function ApiKeysManager() {
 
 			toast({
 				title: "Success",
-				description: "API key created successfully. Copy it now - you won't be able to see it again!",
+				description:
+					"API key created successfully. Copy it now - you won't be able to see it again!",
 			});
 		} catch {
 			toast({
@@ -182,7 +183,10 @@ export function ApiKeysManager() {
 						className="flex-1"
 						disabled={isCreating}
 					/>
-					<Button onClick={createToken} disabled={isCreating || !tokenName.trim()}>
+					<Button
+						onClick={createToken}
+						disabled={isCreating || !tokenName.trim()}
+					>
 						{isCreating ? (
 							"Generating..."
 						) : (
@@ -211,13 +215,14 @@ export function ApiKeysManager() {
 						<Button
 							variant="outline"
 							size="icon"
+							aria-label="Copy API key"
 							onClick={copyToken}
 							className="shrink-0"
 						>
 							{copied ? (
-								<Check className="h-4 w-4 text-green-600" />
+								<Check className="h-4 w-4 text-green-600" aria-hidden="true" />
 							) : (
-								<Copy className="h-4 w-4" />
+								<Copy className="h-4 w-4" aria-hidden="true" />
 							)}
 						</Button>
 					</div>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,7 +1,8 @@
 import type { MetadataRoute } from "next";
 import client from "@/lib/db";
-import { siteConfig } from "@/lib/seo";
 import logger from "@/lib/logger";
+import { siteConfig } from "@/lib/seo";
+import { resolveSitemapLastModified } from "@/lib/sitemap-date";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	const baseUrl = siteConfig.url;
@@ -35,31 +36,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		});
 
 		const messagePages: MetadataRoute.Sitemap = result.rows.map((row) => {
-			// Use approval date if available, otherwise use original date
-			let lastModified: Date;
-
-			try {
-				if (row.approvalDate && Number(row.approvalDate) > 0) {
-					lastModified = new Date(Number(row.approvalDate) * 1000);
-				} else if (row.date && Number(row.date) > 0) {
-					lastModified = new Date(Number(row.date) * 1000);
-				} else {
-					// Fallback to current date if dates are invalid
-					lastModified = new Date();
-				}
-
-				// Validate the date
-				if (Number.isNaN(lastModified.getTime())) {
-					lastModified = new Date();
-				}
-			} catch (_error) {
-				// Fallback to current date if there's any error
-				lastModified = new Date();
-			}
+			const lastModified = resolveSitemapLastModified(
+				row.approvalDate,
+				row.date,
+			);
 
 			return {
 				url: `${baseUrl}/msg/${row.slug}`,
-				lastModified,
+				...(lastModified ? { lastModified } : {}),
 				changeFrequency: "weekly" as const,
 				priority: 0.9,
 			};

--- a/app/submissions/page.tsx
+++ b/app/submissions/page.tsx
@@ -8,7 +8,7 @@ import logger from "@/lib/logger";
 import { SubmissionsTable } from "./submissions-table";
 
 // Force dynamic rendering - this page requires authentication and database
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
 export default async function SubmissionsPage() {
 	const user = await currentUser();
@@ -22,51 +22,54 @@ export default async function SubmissionsPage() {
 		logger.info("Fetching submissions for user", { userId: user.id });
 
 		// Fetch all submission types in parallel for better performance
-		const [pendingSubmissions, deniedSubmissions, approvedSubmissions] = await Promise.all([
-			// Fetch pending (not reviewed) submissions
-			db
-				.select({
-					id: submissions.id,
-					message: submissions.msg,
-					date: submissions.date,
-					submissionStatus: submissions.status,
-				})
-				.from(submissions)
-				.where(
-					and(
-						eq(submissions.clerkUserId, user.id),
-						eq(submissions.status, SUBMISSION_STATUS.PENDING),
+		const [pendingSubmissions, deniedSubmissions, approvedSubmissions] =
+			await Promise.all([
+				// Fetch pending (not reviewed) submissions
+				db
+					.select({
+						id: submissions.id,
+						message: submissions.msg,
+						date: submissions.date,
+						submissionStatus: submissions.status,
+					})
+					.from(submissions)
+					.where(
+						and(
+							eq(submissions.clerkUserId, user.id),
+							eq(submissions.status, SUBMISSION_STATUS.PENDING),
+						),
 					),
-				),
 
-			// Fetch denied submissions
-			db
-				.select({
-					id: submissions.id,
-					message: submissions.msg,
-					date: submissions.date,
-					submissionStatus: submissions.status,
-				})
-				.from(submissions)
-				.where(
-					and(
-						eq(submissions.clerkUserId, user.id),
-						eq(submissions.status, SUBMISSION_STATUS.DENIED),
+				// Fetch denied submissions
+				db
+					.select({
+						id: submissions.id,
+						message: submissions.msg,
+						date: submissions.date,
+						submissionStatus: submissions.status,
+					})
+					.from(submissions)
+					.where(
+						and(
+							eq(submissions.clerkUserId, user.id),
+							eq(submissions.status, SUBMISSION_STATUS.DENIED),
+						),
 					),
-				),
 
-			// Fetch approved submissions (from messages table)
-			db
-				.select({
-					id: messages.id,
-					message: messages.msg,
-					date: messages.date,
-					submissionStatus: sql<number>`${SUBMISSION_STATUS.APPROVED}`.as("submissionStatus"),
-				})
-				.from(messages)
-				.where(eq(messages.clerkUserId, user.id))
-				.orderBy(sql`${messages.date} DESC`),
-		]);
+				// Fetch approved submissions (from messages table)
+				db
+					.select({
+						id: messages.id,
+						message: messages.msg,
+						date: messages.date,
+						submissionStatus: sql<number>`${SUBMISSION_STATUS.APPROVED}`.as(
+							"submissionStatus",
+						),
+					})
+					.from(messages)
+					.where(eq(messages.clerkUserId, user.id))
+					.orderBy(sql`${messages.date} DESC`),
+			]);
 
 		logger.info("Successfully fetched submissions", {
 			pendingCount: pendingSubmissions.length,

--- a/app/submissions/submissions-table.tsx
+++ b/app/submissions/submissions-table.tsx
@@ -29,7 +29,10 @@ function getStatusDisplay(status: number): string {
 	}
 }
 
-export function SubmissionsTable({ submissions, type: _type }: SubmissionsTableProps) {
+export function SubmissionsTable({
+	submissions,
+	type: _type,
+}: SubmissionsTableProps) {
 	const processedSubmissions = submissions.map((sub) => ({
 		id: sub.id,
 		message: sub.message || "",

--- a/biome.json
+++ b/biome.json
@@ -1,12 +1,13 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",
 		"useIgnoreFile": true
 	},
 	"files": {
-		"ignoreUnknown": false
+		"ignoreUnknown": false,
+		"includes": ["**", "!!db/migrations/meta"]
 	},
 	"formatter": {
 		"enabled": true,

--- a/components/MessageList.tsx
+++ b/components/MessageList.tsx
@@ -2,9 +2,9 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { MessageListSkeleton } from "./MessageSkeleton";
 import clientLogger from "@/lib/client-logger";
 import { MESSAGE_POLL_INTERVAL_MS } from "@/lib/constants";
+import { MessageListSkeleton } from "./MessageSkeleton";
 
 export interface Message {
 	id: number;
@@ -91,7 +91,10 @@ export default function MessageList({ initialMessages }: MessageListProps) {
 		fetchLatestMessages();
 
 		// Set up polling for new messages every 30 seconds
-		const intervalId = setInterval(fetchLatestMessages, MESSAGE_POLL_INTERVAL_MS);
+		const intervalId = setInterval(
+			fetchLatestMessages,
+			MESSAGE_POLL_INTERVAL_MS,
+		);
 
 		// Clean up interval on component unmount
 		return () => clearInterval(intervalId);

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -97,12 +97,20 @@ export function Navigation() {
 						)}
 						{isSignedIn && <SettingsDropdown />}
 						{!isSignedIn && (
-							<div className="flex justify-end w-full" role="menuitem" tabIndex={0}>
+							<div
+								className="flex justify-end w-full"
+								role="menuitem"
+								tabIndex={0}
+							>
 								<SignInButton mode="modal" />
 							</div>
 						)}
 						{isSignedIn && (
-							<div className="flex justify-end w-full" role="menuitem" tabIndex={0}>
+							<div
+								className="flex justify-end w-full"
+								role="menuitem"
+								tabIndex={0}
+							>
 								<UserButton />
 							</div>
 						)}

--- a/components/settings-dropdown/index.tsx
+++ b/components/settings-dropdown/index.tsx
@@ -3,7 +3,7 @@
 import { useUser } from "@clerk/nextjs";
 import { ChevronDown, Key, Settings, Shield } from "lucide-react";
 import Link from "next/link";
-import { useState, useRef, useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 
 export function SettingsDropdown() {

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -104,11 +104,11 @@ TableCaption.displayName = "TableCaption";
 
 export {
 	Table,
-	TableHeader,
 	TableBody,
+	TableCaption,
+	TableCell,
 	TableFooter,
 	TableHead,
+	TableHeader,
 	TableRow,
-	TableCell,
-	TableCaption,
 };

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -117,13 +117,13 @@ type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
 type ToastActionElement = React.ReactElement<typeof ToastAction>;
 
 export {
-	type ToastProps,
-	type ToastActionElement,
-	ToastProvider,
-	ToastViewport,
 	Toast,
-	ToastTitle,
-	ToastDescription,
-	ToastClose,
 	ToastAction,
+	type ToastActionElement,
+	ToastClose,
+	ToastDescription,
+	type ToastProps,
+	ToastProvider,
+	ToastTitle,
+	ToastViewport,
 };

--- a/db/client.ts
+++ b/db/client.ts
@@ -1,4 +1,4 @@
-import { createClient, type Client } from "@libsql/client";
+import { type Client, createClient } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
 import { env } from "@/lib/env";
 

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -53,9 +53,7 @@ export const authors = sqliteTable(
 		id: integer("id", { mode: "number" }).primaryKey(),
 		name: text("name"),
 	},
-	(table) => [
-		uniqueIndex("idx_authors_name").on(table.name),
-	],
+	(table) => [uniqueIndex("idx_authors_name").on(table.name)],
 );
 
 export const message_authors = sqliteTable(
@@ -77,10 +75,6 @@ export const message_authors = sqliteTable(
 // Relations
 
 export const messagesRelations = relations(messages, ({ many }) => ({
-	authors: many(message_authors),
-}));
-
-export const submissionsRelations = relations(submissions, ({ many }) => ({
 	authors: many(message_authors),
 }));
 
@@ -137,9 +131,9 @@ export const statements = sqliteTable(
 		createdAt: text("createdAt").notNull(),
 		clerkUserId: text("clerkUserId").notNull(),
 		promotedAt: text("promotedAt"),
-		promotedMessageId: integer("promotedMessageId", { mode: "number" }).references(
-			() => messages.id,
-		),
+		promotedMessageId: integer("promotedMessageId", {
+			mode: "number",
+		}).references(() => messages.id),
 	},
 	(table) => [
 		index("idx_statements_clerkUserId").on(table.clerkUserId),
@@ -161,9 +155,7 @@ export const comparisons = sqliteTable(
 		clerkUserId: text("clerkUserId").notNull(),
 		timestamp: text("timestamp").notNull(),
 	},
-	(table) => [
-		index("idx_comparisons_clerkUserId").on(table.clerkUserId),
-	],
+	(table) => [index("idx_comparisons_clerkUserId").on(table.clerkUserId)],
 );
 
 // Relations for statements

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -188,4 +188,4 @@ function useToast() {
 	};
 }
 
-export { useToast, toast };
+export { toast, useToast };

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -21,3 +21,60 @@ export const SUBMISSION_STATUS = {
 	APPROVED: 2,
 } as const;
 
+export type ApprovalResult =
+	| "approved"
+	| "already-approved"
+	| "already-rejected"
+	| "conflict"
+	| "not-found";
+
+export function getApprovalResult(
+	wasClaimed: boolean,
+	currentStatus?: number,
+): ApprovalResult {
+	if (wasClaimed) {
+		return "approved";
+	}
+	if (currentStatus === undefined) {
+		return "not-found";
+	}
+	if (currentStatus === SUBMISSION_STATUS.APPROVED) {
+		return "already-approved";
+	}
+	return currentStatus === SUBMISSION_STATUS.DENIED
+		? "already-rejected"
+		: "conflict";
+}
+
+export type RejectionTransition = "reject" | "already-rejected" | "conflict";
+export type RejectionResult =
+	| "rejected"
+	| "already-rejected"
+	| "conflict"
+	| "not-found";
+
+export function getRejectionTransition(status: number): RejectionTransition {
+	switch (status) {
+		case SUBMISSION_STATUS.PENDING:
+			return "reject";
+		case SUBMISSION_STATUS.DENIED:
+			return "already-rejected";
+		default:
+			return "conflict";
+	}
+}
+
+export function getRejectionResult(
+	wasUpdated: boolean,
+	currentStatus?: number,
+): RejectionResult {
+	if (wasUpdated) {
+		return "rejected";
+	}
+	if (currentStatus === undefined) {
+		return "not-found";
+	}
+	return getRejectionTransition(currentStatus) === "already-rejected"
+		? "already-rejected"
+		: "conflict";
+}

--- a/lib/message-fetch.ts
+++ b/lib/message-fetch.ts
@@ -1,0 +1,23 @@
+export class MessageFetchError extends Error {
+	constructor(
+		public readonly status: number,
+		statusText: string,
+	) {
+		super(
+			`Message API request failed with status ${status}${statusText ? ` ${statusText}` : ""}`,
+		);
+		this.name = "MessageFetchError";
+	}
+}
+
+export function classifyMessageResponse(
+	response: Pick<Response, "ok" | "status" | "statusText">,
+): "found" | "not-found" {
+	if (response.status === 404) {
+		return "not-found";
+	}
+	if (!response.ok) {
+		throw new MessageFetchError(response.status, response.statusText);
+	}
+	return "found";
+}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -17,6 +17,8 @@ interface RateLimitRecord {
 }
 
 interface RateLimitOptions {
+	/** Stable name used to isolate counters for this policy */
+	policy: string;
 	/** Maximum number of requests allowed in the window */
 	limit: number;
 	/** Time window in milliseconds */
@@ -59,13 +61,18 @@ function cleanupExpiredEntries(windowMs: number): void {
  * rightmost entry — the one Railway recorded — and ignores any client-supplied
  * entries to its left (which would otherwise allow a rate-limit bypass via a
  * forged XFF header). Set to 2 behind Cloudflare→Railway, or 0 for a
- * direct-to-origin deploy with no proxy (XFF is then untrusted).
+ * direct-to-origin deploy with no trusted proxy. With 0 trusted hops, both
+ * forwarding headers are untrusted and the client identifier is "unknown";
+ * Next's headers API does not expose the underlying socket address.
  */
 export async function getClientIP(): Promise<string> {
-	const headersList = await headers();
-
 	const parsed = Number.parseInt(process.env.TRUSTED_PROXY_HOPS ?? "1", 10);
 	const trustedHops = Number.isFinite(parsed) ? Math.max(0, parsed) : 1;
+	if (trustedHops === 0) {
+		return "unknown";
+	}
+
+	const headersList = await headers();
 
 	// x-forwarded-for is a comma-separated list; trusted proxies append on the
 	// right, so the client IP is `trustedHops` entries from the right. Clamp into
@@ -105,17 +112,18 @@ export function checkRateLimit(
 	remaining: number;
 	resetAt: number;
 } {
-	const { limit, windowMs } = options;
+	const { policy, limit, windowMs } = options;
 	const now = Date.now();
+	const storeKey = `${policy}:${identifier}`;
 
 	// Perform periodic cleanup
 	cleanupExpiredEntries(windowMs);
 
-	const record = rateLimitStore.get(identifier);
+	const record = rateLimitStore.get(storeKey);
 
 	// No existing record or window has expired - create new window
 	if (!record || now - record.windowStart > windowMs) {
-		rateLimitStore.set(identifier, { count: 1, windowStart: now });
+		rateLimitStore.set(storeKey, { count: 1, windowStart: now });
 		return {
 			allowed: true,
 			remaining: limit - 1,
@@ -183,16 +191,20 @@ export function addRateLimitHeaders(
 // Default rate limit configurations for different route types
 export const RATE_LIMITS = {
 	// Public read endpoints - generous limits
-	PUBLIC_READ: { limit: 100, windowMs: 60 * 1000 }, // 100 requests per minute
+	PUBLIC_READ: { policy: "public-read", limit: 100, windowMs: 60 * 1000 }, // 100 requests per minute
 
 	// Authenticated write endpoints - moderate limits
-	AUTHENTICATED_WRITE: { limit: 30, windowMs: 60 * 1000 }, // 30 requests per minute
+	AUTHENTICATED_WRITE: {
+		policy: "authenticated-write",
+		limit: 30,
+		windowMs: 60 * 1000,
+	}, // 30 requests per minute
 
 	// Admin endpoints - still limited but higher
-	ADMIN: { limit: 60, windowMs: 60 * 1000 }, // 60 requests per minute
+	ADMIN: { policy: "admin", limit: 60, windowMs: 60 * 1000 }, // 60 requests per minute
 
 	// Sensitive endpoints (token creation) - stricter limits
-	SENSITIVE: { limit: 10, windowMs: 60 * 1000 }, // 10 requests per minute
+	SENSITIVE: { policy: "sensitive", limit: 10, windowMs: 60 * 1000 }, // 10 requests per minute
 } as const;
 
 /**

--- a/lib/sitemap-date.ts
+++ b/lib/sitemap-date.ts
@@ -1,0 +1,94 @@
+const MILLISECONDS_EPOCH_THRESHOLD = 100_000_000_000;
+const ISO_DATE_PATTERN =
+	/^(\d{4})-(\d{2})-(\d{2})(?:[Tt](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?(?:[Zz]|[+-](\d{2}):?(\d{2}))?)?$/;
+
+function validDate(value: string | number | Date): Date | undefined {
+	const date = new Date(value);
+	return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+function parseISODate(value: string): Date | undefined {
+	const match = ISO_DATE_PATTERN.exec(value);
+	if (!match) {
+		return undefined;
+	}
+
+	const [, yearText, monthText, dayText, hourText, minuteText, secondText] =
+		match;
+	const year = Number(yearText);
+	const month = Number(monthText);
+	const day = Number(dayText);
+	const isLeapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+	const daysInMonth = [
+		31,
+		isLeapYear ? 29 : 28,
+		31,
+		30,
+		31,
+		30,
+		31,
+		31,
+		30,
+		31,
+		30,
+		31,
+	];
+
+	if (month < 1 || month > 12 || day < 1 || day > daysInMonth[month - 1]) {
+		return undefined;
+	}
+	if (
+		(hourText !== undefined && Number(hourText) > 23) ||
+		(minuteText !== undefined && Number(minuteText) > 59) ||
+		(secondText !== undefined && Number(secondText) > 59)
+	) {
+		return undefined;
+	}
+
+	const date = validDate(value);
+	if (!date) {
+		return undefined;
+	}
+	if (!hourText && date.toISOString().slice(0, 10) !== value) {
+		return undefined;
+	}
+	return date;
+}
+
+export function parseSitemapDate(value: unknown): Date | undefined {
+	if (value instanceof Date) {
+		return validDate(value);
+	}
+
+	if (typeof value === "number" || typeof value === "bigint") {
+		const timestamp = Number(value);
+		if (!Number.isFinite(timestamp)) {
+			return undefined;
+		}
+		const milliseconds =
+			Math.abs(timestamp) < MILLISECONDS_EPOCH_THRESHOLD
+				? timestamp * 1000
+				: timestamp;
+		return validDate(milliseconds);
+	}
+
+	if (typeof value !== "string" || value.trim() === "") {
+		return undefined;
+	}
+
+	const normalized = value.trim();
+	if (/^[+-]?(?:\d+\.?\d*|\.\d+)$/.test(normalized)) {
+		return parseSitemapDate(Number(normalized));
+	}
+	if (/^\d{4}-\d{2}-\d{2}/.test(normalized)) {
+		return parseISODate(normalized);
+	}
+	return undefined;
+}
+
+export function resolveSitemapLastModified(
+	approvalDate: unknown,
+	originalDate: unknown,
+): Date | undefined {
+	return parseSitemapDate(approvalDate) ?? parseSitemapDate(originalDate);
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,6 @@
 import { clerkMiddleware } from "@clerk/nextjs/server";
-import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 
 /**
  * Security headers for all responses.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"packageManager": "pnpm@11.1.3",
 	"engines": {
-		"node": ">=22.0.0"
+		"node": "^22.18.0 || >=24.11.0"
 	},
 	"scripts": {
 		"dev": "next dev --turbopack",
@@ -23,8 +23,8 @@
 		"delete-message": "tsx scripts/delete-message.ts"
 	},
 	"dependencies": {
-		"@babel/helpers": "^7.29.7",
-		"@clerk/nextjs": "^7.5.13",
+		"@babel/helpers": "^8.0.0",
+		"@clerk/nextjs": "^7.5.20",
 		"@libsql/client": "^0.17.4",
 		"@radix-ui/react-slot": "^1.3.0",
 		"@radix-ui/react-toast": "^1.2.19",
@@ -33,34 +33,34 @@
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"drizzle-orm": "^0.45.2",
-		"lucide-react": "^1.23.0",
+		"lucide-react": "^1.25.0",
 		"next": "16.2.10",
 		"react": "^19.2.7",
 		"react-dom": "^19.2.7",
 		"tailwind-merge": "^3.6.0",
-		"tailwindcss-animate": "^1.0.7",
 		"winston": "^3.19.0",
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.5.2",
+		"@biomejs/biome": "^2.5.4",
 		"@jest/globals": "^30.4.1",
 		"@next/env": "^16.2.10",
-		"@tailwindcss/postcss": "^4.3.2",
+		"@tailwindcss/postcss": "^4.3.3",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@types/better-sqlite3": "^7.6.13",
 		"@types/jest": "^30.0.0",
-		"@types/node": "^25.9.1",
+		"@types/node": "^26.1.1",
 		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",
 		"drizzle-kit": "^0.31.10",
 		"jest": "^30.4.2",
 		"jest-environment-jsdom": "30.4.1",
-		"postcss": "^8.5.16",
-		"tailwindcss": "^4.3.2",
+		"postcss": "^8.5.19",
+		"tailwindcss": "^4.3.3",
 		"ts-jest": "^29.4.11",
-		"tsx": "^4.23.0",
+		"tsx": "^4.23.1",
+		"tw-animate-css": "^1.4.0",
 		"typescript": "^6.0.3"
 	},
 	"jest": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   ws: ^8.21.0
   js-yaml: ^4.1.2
   '@babel/core': ^7.29.1
-  postcss: ^8.5.15
+  postcss: ^8.5.19
 
 importers:
 
@@ -2671,10 +2671,6 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.19:
     resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4268,7 +4264,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
-      postcss: 8.5.16
+      postcss: 8.5.19
       tailwindcss: 4.3.3
 
   '@tanstack/query-core@5.101.2': {}
@@ -5596,7 +5592,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.29
       caniuse-lite: 1.0.30001792
-      postcss: 8.5.16
+      postcss: 8.5.19
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
@@ -5689,12 +5685,6 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
-
-  postcss@8.5.16:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.19:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,11 +17,11 @@ importers:
   .:
     dependencies:
       '@babel/helpers':
-        specifier: ^7.29.7
-        version: 7.29.7
+        specifier: ^8.0.0
+        version: 8.0.0
       '@clerk/nextjs':
-        specifier: ^7.5.13
-        version: 7.5.13(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^7.5.20
+        version: 7.5.20(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@libsql/client':
         specifier: ^0.17.4
         version: 0.17.4
@@ -47,8 +47,8 @@ importers:
         specifier: ^0.45.2
         version: 0.45.2(@libsql/client@0.17.4)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)
       lucide-react:
-        specifier: ^1.23.0
-        version: 1.23.0(react@19.2.7)
+        specifier: ^1.25.0
+        version: 1.25.0(react@19.2.7)
       next:
         specifier: 16.2.10
         version: 16.2.10(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -61,9 +61,6 @@ importers:
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
-      tailwindcss-animate:
-        specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@4.3.2)
       winston:
         specifier: ^3.19.0
         version: 3.19.0
@@ -72,8 +69,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.2
-        version: 2.5.2
+        specifier: ^2.5.4
+        version: 2.5.4
       '@jest/globals':
         specifier: ^30.4.1
         version: 30.4.1
@@ -81,8 +78,8 @@ importers:
         specifier: ^16.2.10
         version: 16.2.10
       '@tailwindcss/postcss':
-        specifier: ^4.3.2
-        version: 4.3.2
+        specifier: ^4.3.3
+        version: 4.3.3
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -96,8 +93,8 @@ importers:
         specifier: ^30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: ^25.9.1
-        version: 25.9.1
+        specifier: ^26.1.1
+        version: 26.1.1
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -109,22 +106,25 @@ importers:
         version: 0.31.10
       jest:
         specifier: ^30.4.2
-        version: 30.4.2(@types/node@25.9.1)
+        version: 30.4.2(@types/node@26.1.1)
       jest-environment-jsdom:
         specifier: 30.4.1
         version: 30.4.1
       postcss:
-        specifier: ^8.5.15
-        version: 8.5.16
+        specifier: ^8.5.19
+        version: 8.5.19
       tailwindcss:
-        specifier: ^4.3.2
-        version: 4.3.2
+        specifier: ^4.3.3
+        version: 4.3.3
       ts-jest:
         specifier: ^29.4.11
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1))(typescript@6.0.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@26.1.1))(typescript@6.0.3)
       tsx:
-        specifier: ^4.23.0
-        version: 4.23.0
+        specifier: ^4.23.1
+        version: 4.23.1
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -145,13 +145,13 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/code-frame@8.0.0':
+    resolution: {integrity: sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/compat-data@7.29.7':
     resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
@@ -191,21 +191,21 @@ packages:
     resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
-    engines: {node: '>=6.9.0'}
+  '@babel/helper-string-parser@8.0.0':
+    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@8.0.4':
+    resolution: {integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-option@7.29.7':
     resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
@@ -215,14 +215,18 @@ packages:
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.3':
-    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
+  '@babel/helpers@8.0.0':
+    resolution: {integrity: sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@8.0.4':
+    resolution: {integrity: sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
   '@babel/plugin-syntax-async-generators@7.8.4':
@@ -328,99 +332,103 @@ packages:
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@8.0.0':
+    resolution: {integrity: sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/types@8.0.4':
+    resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@biomejs/biome@2.5.2':
-    resolution: {integrity: sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA==}
+  '@biomejs/biome@2.5.4':
+    resolution: {integrity: sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.5.2':
-    resolution: {integrity: sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg==}
+  '@biomejs/cli-darwin-arm64@2.5.4':
+    resolution: {integrity: sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.5.2':
-    resolution: {integrity: sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g==}
+  '@biomejs/cli-darwin-x64@2.5.4':
+    resolution: {integrity: sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.5.2':
-    resolution: {integrity: sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw==}
+  '@biomejs/cli-linux-arm64-musl@2.5.4':
+    resolution: {integrity: sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.5.2':
-    resolution: {integrity: sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ==}
+  '@biomejs/cli-linux-arm64@2.5.4':
+    resolution: {integrity: sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.5.2':
-    resolution: {integrity: sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw==}
+  '@biomejs/cli-linux-x64-musl@2.5.4':
+    resolution: {integrity: sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.5.2':
-    resolution: {integrity: sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA==}
+  '@biomejs/cli-linux-x64@2.5.4':
+    resolution: {integrity: sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.5.2':
-    resolution: {integrity: sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww==}
+  '@biomejs/cli-win32-arm64@2.5.4':
+    resolution: {integrity: sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.5.2':
-    resolution: {integrity: sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A==}
+  '@biomejs/cli-win32-x64@2.5.4':
+    resolution: {integrity: sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
 
-  '@clerk/backend@3.11.0':
-    resolution: {integrity: sha512-msK+Mvc8tmX3o8UTL6r9h7dodW9vPLvDjyVWLM0yLe5kuvvV5ag70O1qt5SXTCZd7HruS3MAuwUzn3PoQHoT3g==}
+  '@clerk/backend@3.11.7':
+    resolution: {integrity: sha512-il2wyzS2I10Gv8v+ECEKQqDfaW7gCD2BWUZp37LOMFBn6/DJ7FhHfe4XwgQLUDBkHyk2LxyTt3Lbg5GnpNJPUQ==}
     engines: {node: '>=20.9.0'}
 
-  '@clerk/nextjs@7.5.13':
-    resolution: {integrity: sha512-8kFy9ZronzX33ukOm8LJ7IL8ioVTSRb8ZPN7xyz4ZEwFhjRpXwagJR3v/TSiwtlUEU0eydpFyT2pWPH8jvdf5A==}
+  '@clerk/nextjs@7.5.20':
+    resolution: {integrity: sha512-ZyrRuYw9dAz7EnxDf0meb2O/rKlGJ6oB5UKcYu+BGqzORz5HK4i8zEhhjjF4PnTkRNl90eUDR2rxPWtgI2Q9wQ==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       next: ^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
 
-  '@clerk/react@6.11.4':
-    resolution: {integrity: sha512-3ft1broqXA6hSMXOhnVwEXDCqmaXSvYW65au6fOdhc26YPQbLL6e56FkJ4y/1c3uObpivuwe9MXj3ln4ZD0zmw==}
+  '@clerk/react@6.12.5':
+    resolution: {integrity: sha512-sPO67Ikeh+r9Mu0jEinEHlkmzYf0VSCGHNIf4ueCHT1H6+wDzrXZS08uFB3Tv4jd6IZJdXSEXDr51NAn+86Jiw==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
 
-  '@clerk/shared@4.24.0':
-    resolution: {integrity: sha512-QgAihmKS4ld3YSqSPMaKnzU4RGV+60k5khcjiz0xi4BCUST+UJAbV8f3Hw0osxq/Rw9rsxmRlcoxhEMsN5SOFA==}
+  '@clerk/shared@4.25.5':
+    resolution: {integrity: sha512-pb+pA+88OACHSuE0JhsnV7Qzl1j9UhI9KrXivS831x1BJOtNYORnDqRg3xss2SPFcC46clE9S5QqkRQqv1lSsg==}
     engines: {node: '>=20.9.0'}
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
@@ -1237,69 +1245,69 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
-  '@tailwindcss/node@4.3.2':
-    resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
+  '@tailwindcss/node@4.3.3':
+    resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
 
-  '@tailwindcss/oxide-android-arm64@4.3.2':
-    resolution: {integrity: sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==}
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    resolution: {integrity: sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
 
-  '@tailwindcss/oxide-darwin-arm64@4.3.2':
-    resolution: {integrity: sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==}
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    resolution: {integrity: sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
 
-  '@tailwindcss/oxide-darwin-x64@4.3.2':
-    resolution: {integrity: sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==}
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    resolution: {integrity: sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
-  '@tailwindcss/oxide-freebsd-x64@4.3.2':
-    resolution: {integrity: sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==}
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    resolution: {integrity: sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [freebsd]
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
-    resolution: {integrity: sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==}
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    resolution: {integrity: sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==}
     engines: {node: '>= 20'}
     cpu: [arm]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
-    resolution: {integrity: sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==}
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    resolution: {integrity: sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
-    resolution: {integrity: sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==}
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
-    resolution: {integrity: sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==}
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
-    resolution: {integrity: sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==}
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
-    resolution: {integrity: sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==}
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
     bundledDependencies:
@@ -1310,24 +1318,24 @@ packages:
       - '@emnapi/wasi-threads'
       - tslib
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
-    resolution: {integrity: sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==}
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    resolution: {integrity: sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [win32]
 
-  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
-    resolution: {integrity: sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==}
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    resolution: {integrity: sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
 
-  '@tailwindcss/oxide@4.3.2':
-    resolution: {integrity: sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==}
+  '@tailwindcss/oxide@4.3.3':
+    resolution: {integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==}
     engines: {node: '>= 20'}
 
-  '@tailwindcss/postcss@4.3.2':
-    resolution: {integrity: sha512-rjVWYCa7Ngbi5AarT6k8TkxUG3Wl1QKzHdIZVsjZSzf36Jmo2IKZt/NHRAwly8oDkbBOH0YTu+CHuf9jPxMc+g==}
+  '@tailwindcss/postcss@4.3.3':
+    resolution: {integrity: sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==}
 
   '@tanstack/query-core@5.101.2':
     resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
@@ -1402,11 +1410,11 @@ packages:
   '@types/jsdom@21.1.7':
     resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
 
-  '@types/node@25.9.0':
-    resolution: {integrity: sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==}
-
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
+  '@types/node@26.1.1':
+    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -1936,8 +1944,8 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  enhanced-resolve@5.21.6:
-    resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
+  enhanced-resolve@5.24.2:
+    resolution: {integrity: sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==}
     engines: {node: '>=10.13.0'}
 
   entities@6.0.1:
@@ -2336,6 +2344,9 @@ packages:
     resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
     engines: {node: '>=20'}
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2471,8 +2482,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@1.23.0:
-    resolution: {integrity: sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==}
+  lucide-react@1.25.0:
+    resolution: {integrity: sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -2662,6 +2673,10 @@ packages:
 
   postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
@@ -2899,13 +2914,8 @@ packages:
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
-  tailwindcss-animate@1.0.7:
-    resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
-    peerDependencies:
-      tailwindcss: '>=3.0.0 || insiders'
-
-  tailwindcss@4.3.2:
-    resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
+  tailwindcss@4.3.3:
+    resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
@@ -2986,8 +2996,16 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tsx@4.23.1:
+    resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  tw-animate-css@1.4.0:
+    resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
   type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
@@ -3013,6 +3031,9 @@ packages:
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -3142,13 +3163,7 @@ snapshots:
 
   '@babel/code-frame@7.27.1':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
-  '@babel/code-frame@7.29.0':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -3157,6 +3172,11 @@ snapshots:
       '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
+
+  '@babel/code-frame@8.0.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 8.0.4
+      js-tokens: 10.0.0
 
   '@babel/compat-data@7.29.7': {}
 
@@ -3182,8 +3202,8 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -3224,13 +3244,13 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
-  '@babel/helper-string-parser@7.27.1': {}
-
   '@babel/helper-string-parser@7.29.7': {}
 
-  '@babel/helper-validator-identifier@7.28.5': {}
+  '@babel/helper-string-parser@8.0.0': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-identifier@8.0.4': {}
 
   '@babel/helper-validator-option@7.29.7': {}
 
@@ -3239,13 +3259,18 @@ snapshots:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/parser@7.29.3':
+  '@babel/helpers@8.0.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/template': 8.0.0
+      '@babel/types': 8.0.4
 
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/parser@8.0.4':
+    dependencies:
+      '@babel/types': 8.0.4
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7)':
     dependencies:
@@ -3342,6 +3367,12 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
+  '@babel/template@8.0.0':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/types': 8.0.4
+
   '@babel/traverse@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -3354,81 +3385,81 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.29.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
-
   '@babel/types@7.29.7':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@babel/types@8.0.4':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.4
+
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@biomejs/biome@2.5.2':
+  '@biomejs/biome@2.5.4':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.5.2
-      '@biomejs/cli-darwin-x64': 2.5.2
-      '@biomejs/cli-linux-arm64': 2.5.2
-      '@biomejs/cli-linux-arm64-musl': 2.5.2
-      '@biomejs/cli-linux-x64': 2.5.2
-      '@biomejs/cli-linux-x64-musl': 2.5.2
-      '@biomejs/cli-win32-arm64': 2.5.2
-      '@biomejs/cli-win32-x64': 2.5.2
+      '@biomejs/cli-darwin-arm64': 2.5.4
+      '@biomejs/cli-darwin-x64': 2.5.4
+      '@biomejs/cli-linux-arm64': 2.5.4
+      '@biomejs/cli-linux-arm64-musl': 2.5.4
+      '@biomejs/cli-linux-x64': 2.5.4
+      '@biomejs/cli-linux-x64-musl': 2.5.4
+      '@biomejs/cli-win32-arm64': 2.5.4
+      '@biomejs/cli-win32-x64': 2.5.4
 
-  '@biomejs/cli-darwin-arm64@2.5.2':
+  '@biomejs/cli-darwin-arm64@2.5.4':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.5.2':
+  '@biomejs/cli-darwin-x64@2.5.4':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.5.2':
+  '@biomejs/cli-linux-arm64-musl@2.5.4':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.5.2':
+  '@biomejs/cli-linux-arm64@2.5.4':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.5.2':
+  '@biomejs/cli-linux-x64-musl@2.5.4':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.5.2':
+  '@biomejs/cli-linux-x64@2.5.4':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.5.2':
+  '@biomejs/cli-win32-arm64@2.5.4':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.5.2':
+  '@biomejs/cli-win32-x64@2.5.4':
     optional: true
 
-  '@clerk/backend@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@clerk/backend@3.11.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@clerk/shared': 4.24.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@clerk/shared': 4.25.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       standardwebhooks: 1.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@clerk/nextjs@7.5.13(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@clerk/nextjs@7.5.20(next@16.2.10(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@clerk/backend': 3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@clerk/react': 6.11.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@clerk/shared': 4.24.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@clerk/backend': 3.11.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@clerk/react': 6.12.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@clerk/shared': 4.25.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next: 16.2.10(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       server-only: 0.0.1
       tslib: 2.8.1
 
-  '@clerk/react@6.11.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@clerk/react@6.12.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@clerk/shared': 4.24.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@clerk/shared': 4.25.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       tslib: 2.8.1
 
-  '@clerk/shared@4.24.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@clerk/shared@4.25.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@tanstack/query-core': 5.101.2
       dequal: 2.0.3
@@ -3688,7 +3719,7 @@ snapshots:
   '@jest/console@30.4.1':
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       chalk: 4.1.2
       jest-message-util: 30.4.1
       jest-util: 30.4.1
@@ -3702,7 +3733,7 @@ snapshots:
       '@jest/test-result': 30.4.1
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
@@ -3710,7 +3741,7 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
       jest-changed-files: 30.4.1
-      jest-config: 30.4.2(@types/node@25.9.0)
+      jest-config: 30.4.2(@types/node@25.9.1)
       jest-haste-map: 30.4.1
       jest-message-util: 30.4.1
       jest-regex-util: 30.4.0
@@ -3740,7 +3771,7 @@ snapshots:
       '@jest/fake-timers': 30.4.1
       '@jest/types': 30.4.1
       '@types/jsdom': 21.1.7
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       jest-mock: 30.4.1
       jest-util: 30.4.1
       jsdom: 26.1.0
@@ -3749,7 +3780,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       jest-mock: 30.4.1
 
   '@jest/expect-utils@30.0.3':
@@ -3771,7 +3802,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.4.1
       '@sinonjs/fake-timers': 15.4.0
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       jest-message-util: 30.4.1
       jest-mock: 30.4.1
       jest-util: 30.4.1
@@ -3791,12 +3822,12 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       jest-regex-util: 30.0.1
 
   '@jest/pattern@30.4.0':
     dependencies:
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       jest-regex-util: 30.4.0
 
   '@jest/reporters@30.4.1':
@@ -3807,7 +3838,7 @@ snapshots:
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -3887,7 +3918,7 @@ snapshots:
       '@jest/schemas': 30.0.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -3897,7 +3928,7 @@ snapshots:
       '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -4171,74 +4202,74 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tailwindcss/node@4.3.2':
+  '@tailwindcss/node@4.3.3':
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      enhanced-resolve: 5.21.6
+      enhanced-resolve: 5.24.2
       jiti: 2.7.0
       lightningcss: 1.32.0
       magic-string: 0.30.21
       source-map-js: 1.2.1
-      tailwindcss: 4.3.2
+      tailwindcss: 4.3.3
 
-  '@tailwindcss/oxide-android-arm64@4.3.2':
+  '@tailwindcss/oxide-android-arm64@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-darwin-arm64@4.3.2':
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-darwin-x64@4.3.2':
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-freebsd-x64@4.3.2':
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide@4.3.2':
+  '@tailwindcss/oxide@4.3.3':
     optionalDependencies:
-      '@tailwindcss/oxide-android-arm64': 4.3.2
-      '@tailwindcss/oxide-darwin-arm64': 4.3.2
-      '@tailwindcss/oxide-darwin-x64': 4.3.2
-      '@tailwindcss/oxide-freebsd-x64': 4.3.2
-      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.2
-      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.2
-      '@tailwindcss/oxide-linux-arm64-musl': 4.3.2
-      '@tailwindcss/oxide-linux-x64-gnu': 4.3.2
-      '@tailwindcss/oxide-linux-x64-musl': 4.3.2
-      '@tailwindcss/oxide-wasm32-wasi': 4.3.2
-      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.2
-      '@tailwindcss/oxide-win32-x64-msvc': 4.3.2
+      '@tailwindcss/oxide-android-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-x64': 4.3.3
+      '@tailwindcss/oxide-freebsd-x64': 4.3.3
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.3
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.3
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.3
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
 
-  '@tailwindcss/postcss@4.3.2':
+  '@tailwindcss/postcss@4.3.3':
     dependencies:
       '@alloc/quick-lru': 5.2.0
-      '@tailwindcss/node': 4.3.2
-      '@tailwindcss/oxide': 4.3.2
+      '@tailwindcss/node': 4.3.3
+      '@tailwindcss/oxide': 4.3.3
       postcss: 8.5.16
-      tailwindcss: 4.3.2
+      tailwindcss: 4.3.3
 
   '@tanstack/query-core@5.101.2': {}
 
@@ -4310,7 +4341,7 @@ snapshots:
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -4329,17 +4360,17 @@ snapshots:
 
   '@types/jsdom@21.1.7':
     dependencies:
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
-
-  '@types/node@25.9.0':
-    dependencies:
-      undici-types: 7.24.6
 
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
+
+  '@types/node@26.1.1':
+    dependencies:
+      undici-types: 8.3.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
@@ -4711,7 +4742,7 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  enhanced-resolve@5.21.6:
+  enhanced-resolve@5.24.2:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
@@ -4979,7 +5010,7 @@ snapshots:
       '@jest/expect': 30.4.1
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -4999,7 +5030,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.4.2(@types/node@25.9.1):
+  jest-cli@30.4.2(@types/node@26.1.1):
     dependencies:
       '@jest/core': 30.4.2
       '@jest/test-result': 30.4.1
@@ -5007,7 +5038,7 @@ snapshots:
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.4.2(@types/node@25.9.1)
+      jest-config: 30.4.2(@types/node@26.1.1)
       jest-util: 30.4.1
       jest-validate: 30.4.1
       yargs: 17.7.2
@@ -5017,37 +5048,6 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
-
-  jest-config@30.4.2(@types/node@25.9.0):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.4.0
-      '@jest/test-sequencer': 30.4.1
-      '@jest/types': 30.4.1
-      babel-jest: 30.4.1(@babel/core@7.29.7)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.4.2
-      jest-docblock: 30.4.0
-      jest-environment-node: 30.4.1
-      jest-regex-util: 30.4.0
-      jest-resolve: 30.4.1
-      jest-runner: 30.4.2
-      jest-util: 30.4.1
-      jest-validate: 30.4.1
-      parse-json: 5.2.0
-      pretty-format: 30.4.1
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.9.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
 
   jest-config@30.4.2(@types/node@25.9.1):
     dependencies:
@@ -5076,6 +5076,37 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.9.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.4.2(@types/node@26.1.1):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.4.0
+      '@jest/test-sequencer': 30.4.1
+      '@jest/types': 30.4.1
+      babel-jest: 30.4.1(@babel/core@7.29.7)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.4.2
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-runner: 30.4.2
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      parse-json: 5.2.0
+      pretty-format: 30.4.1
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 26.1.1
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -5121,7 +5152,7 @@ snapshots:
       '@jest/environment': 30.4.1
       '@jest/fake-timers': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       jest-mock: 30.4.1
       jest-util: 30.4.1
       jest-validate: 30.4.1
@@ -5129,7 +5160,7 @@ snapshots:
   jest-haste-map@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -5174,7 +5205,7 @@ snapshots:
 
   jest-message-util@30.4.1:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@jest/types': 30.4.1
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -5188,13 +5219,13 @@ snapshots:
   jest-mock@30.0.2:
     dependencies:
       '@jest/types': 30.0.1
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       jest-util: 30.0.2
 
   jest-mock@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       jest-util: 30.4.1
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.4.1):
@@ -5230,7 +5261,7 @@ snapshots:
       '@jest/test-result': 30.4.1
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -5259,7 +5290,7 @@ snapshots:
       '@jest/test-result': 30.4.1
       '@jest/transform': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -5283,7 +5314,7 @@ snapshots:
       '@babel/generator': 7.29.1
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.7)
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.7)
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@jest/expect-utils': 30.4.1
       '@jest/get-type': 30.1.0
       '@jest/snapshot-utils': 30.4.1
@@ -5306,7 +5337,7 @@ snapshots:
   jest-util@30.0.2:
     dependencies:
       '@jest/types': 30.0.1
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       chalk: 4.1.2
       ci-info: 4.2.0
       graceful-fs: 4.2.11
@@ -5315,7 +5346,7 @@ snapshots:
   jest-util@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -5334,7 +5365,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -5343,18 +5374,18 @@ snapshots:
 
   jest-worker@30.4.1:
     dependencies:
-      '@types/node': 25.9.0
+      '@types/node': 25.9.1
       '@ungap/structured-clone': 1.3.1
       jest-util: 30.4.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.4.2(@types/node@25.9.1):
+  jest@30.4.2(@types/node@26.1.1):
     dependencies:
       '@jest/core': 30.4.2
       '@jest/types': 30.4.1
       import-local: 3.2.0
-      jest-cli: 30.4.2(@types/node@25.9.1)
+      jest-cli: 30.4.2(@types/node@26.1.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5367,6 +5398,8 @@ snapshots:
   js-base64@3.7.7: {}
 
   js-cookie@3.0.7: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -5498,7 +5531,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@1.23.0(react@19.2.7):
+  lucide-react@1.25.0(react@19.2.7):
     dependencies:
       react: 19.2.7
 
@@ -5627,7 +5660,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -5658,6 +5691,12 @@ snapshots:
       find-up: 4.1.0
 
   postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.19:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -5910,11 +5949,7 @@ snapshots:
 
   tailwind-merge@3.6.0: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@4.3.2):
-    dependencies:
-      tailwindcss: 4.3.2
-
-  tailwindcss@4.3.2: {}
+  tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
 
@@ -5963,12 +5998,12 @@ snapshots:
 
   triple-beam@1.4.1: {}
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.9.1))(typescript@6.0.3):
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@26.1.1))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.4.2(@types/node@25.9.1)
+      jest: 30.4.2(@types/node@26.1.1)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -5991,9 +6026,17 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tsx@4.23.1:
+    dependencies:
+      esbuild: 0.25.4
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  tw-animate-css@1.4.0: {}
 
   type-detect@4.0.8: {}
 
@@ -6007,6 +6050,8 @@ snapshots:
     optional: true
 
   undici-types@7.24.6: {}
+
+  undici-types@8.3.0: {}
 
   unrs-resolver@1.11.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,4 +20,4 @@ overrides:
   ws: ^8.21.0 # CVE: ws memory-exhaustion DoS (fixed in 8.21.0)
   js-yaml: ^4.1.2 # CVE: js-yaml quadratic-complexity DoS via merge keys
   '@babel/core': ^7.29.1 # CVE: @babel/core arbitrary file read via sourceMappingURL
-  postcss: ^8.5.15
+  postcss: ^8.5.19

--- a/scripts/backfill-token-hashes.ts
+++ b/scripts/backfill-token-hashes.ts
@@ -37,7 +37,9 @@ async function backfillTokenHashes(): Promise<void> {
 		}
 	});
 
-	console.log(`✅ Hashed ${toBackfill.length} of ${rows.length} api_tokens row(s).`);
+	console.log(
+		`✅ Hashed ${toBackfill.length} of ${rows.length} api_tokens row(s).`,
+	);
 }
 
 backfillTokenHashes()

--- a/scripts/delete-message.ts
+++ b/scripts/delete-message.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env tsx
 /**
  * Script to delete a message and all related records
- * 
+ *
  * Usage:
  *   pnpm tsx scripts/delete-message.ts <message-id>
  *   pnpm tsx scripts/delete-message.ts <message-slug>
@@ -13,7 +13,7 @@ async function deleteMessage(identifier: string | number) {
 	try {
 		// First, find the message by ID or slug
 		let messageId: number | null = null;
-		
+
 		if (typeof identifier === "number" || !Number.isNaN(Number(identifier))) {
 			// If it's a number, treat as ID
 			messageId = Number(identifier);
@@ -23,52 +23,52 @@ async function deleteMessage(identifier: string | number) {
 				sql: "SELECT id FROM messages WHERE slug = ?",
 				args: [identifier],
 			});
-			
+
 			if (slugResult.rows.length === 0) {
 				console.error(`❌ Message not found with slug: ${identifier}`);
 				process.exit(1);
 			}
-			
+
 			messageId = slugResult.rows[0].id as number;
 		}
-		
+
 		// Verify message exists
 		const messageResult = await rawClient.execute({
 			sql: "SELECT id, msg, slug FROM messages WHERE id = ?",
 			args: [messageId],
 		});
-		
+
 		if (messageResult.rows.length === 0) {
 			console.error(`❌ Message not found with ID: ${messageId}`);
 			process.exit(1);
 		}
-		
+
 		const message = messageResult.rows[0];
 		console.log(`📝 Found message:`);
 		console.log(`   ID: ${message.id}`);
 		console.log(`   Slug: ${message.slug}`);
 		console.log(`   Preview: ${(message.msg as string).substring(0, 50)}...`);
-		
+
 		// Check for related records
 		const authorCountResult = await rawClient.execute({
 			sql: "SELECT COUNT(*) as count FROM message_authors WHERE messageId = ?",
 			args: [messageId],
 		});
 		const authorCount = authorCountResult.rows[0].count as number;
-		
+
 		const statementCountResult = await rawClient.execute({
 			sql: "SELECT COUNT(*) as count FROM statements WHERE promotedMessageId = ?",
 			args: [messageId],
 		});
 		const statementCount = statementCountResult.rows[0].count as number;
-		
+
 		console.log(`\n📊 Related records:`);
 		console.log(`   message_authors: ${authorCount}`);
 		console.log(`   statements (promoted): ${statementCount}`);
-		
+
 		// Delete related records first
 		console.log(`\n🗑️  Deleting related records...`);
-		
+
 		if (authorCount > 0) {
 			await rawClient.execute({
 				sql: "DELETE FROM message_authors WHERE messageId = ?",
@@ -76,25 +76,28 @@ async function deleteMessage(identifier: string | number) {
 			});
 			console.log(`   ✓ Deleted ${authorCount} author relationship(s)`);
 		}
-		
+
 		if (statementCount > 0) {
 			// Set promotedMessageId to NULL instead of deleting statements
 			await rawClient.execute({
 				sql: "UPDATE statements SET promotedMessageId = NULL WHERE promotedMessageId = ?",
 				args: [messageId],
 			});
-			console.log(`   ✓ Cleared promotedMessageId from ${statementCount} statement(s)`);
+			console.log(
+				`   ✓ Cleared promotedMessageId from ${statementCount} statement(s)`,
+			);
 		}
-		
+
 		// Finally, delete the message
 		console.log(`\n🗑️  Deleting message...`);
 		await rawClient.execute({
 			sql: "DELETE FROM messages WHERE id = ?",
 			args: [messageId],
 		});
-		
-		console.log(`\n✅ Successfully deleted message ID ${messageId} (slug: ${message.slug})`);
-		
+
+		console.log(
+			`\n✅ Successfully deleted message ID ${messageId} (slug: ${message.slug})`,
+		);
 	} catch (error) {
 		console.error("❌ Error deleting message:", error);
 		process.exit(1);
@@ -106,11 +109,12 @@ const identifier = process.argv[2];
 
 if (!identifier) {
 	console.error("❌ Please provide a message ID or slug");
-	console.error("Usage: pnpm tsx scripts/delete-message.ts <message-id-or-slug>");
+	console.error(
+		"Usage: pnpm tsx scripts/delete-message.ts <message-id-or-slug>",
+	);
 	process.exit(1);
 }
 
 deleteMessage(identifier).then(() => {
 	process.exit(0);
 });
-

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -80,5 +80,4 @@ module.exports = {
 			},
 		},
 	},
-	plugins: [require("tailwindcss-animate")],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,43 +1,35 @@
 {
-  "compilerOptions": {
-    "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "ignoreDeprecations": "6.0",
-    "rootDir": ".",
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "incremental": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "paths": {
-      "@/*": [
-        "./*"
-      ]
-    }
-  },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+	"compilerOptions": {
+		"target": "ES2017",
+		"lib": ["dom", "dom.iterable", "esnext"],
+		"allowJs": true,
+		"skipLibCheck": true,
+		"strict": true,
+		"ignoreDeprecations": "6.0",
+		"rootDir": ".",
+		"noEmit": true,
+		"esModuleInterop": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"jsx": "react-jsx",
+		"incremental": true,
+		"plugins": [
+			{
+				"name": "next"
+			}
+		],
+		"paths": {
+			"@/*": ["./*"]
+		}
+	},
+	"include": [
+		"next-env.d.ts",
+		"**/*.ts",
+		"**/*.tsx",
+		".next/types/**/*.ts",
+		".next/dev/types/**/*.ts"
+	],
+	"exclude": ["node_modules"]
 }

--- a/utils/text.ts
+++ b/utils/text.ts
@@ -1,5 +1,8 @@
 import { createHash } from "node:crypto";
 
+const MAX_SLUG_LENGTH = 50;
+const HASH_SUFFIX_LENGTH = 8;
+
 const charMap: { [key: string]: string } = {
 	À: "A",
 	Á: "A",
@@ -90,15 +93,18 @@ export function generateMD5(content: string): string {
 }
 
 export function generateSlug(text: string, hash?: string): string {
-	if (containsNonLatinCharacters(text)) {
-		return hash || generateMD5(text);
-	}
-
 	// 1. Map characters using charMap
 	const mappedText = text
 		.split("")
 		.map((char) => charMap[char] || char)
 		.join("");
+	const wasTransliterated = mappedText !== text;
+
+	// Reject unsupported scripts and punctuation only after supported accented
+	// characters have been converted to the allowed ASCII set.
+	if (containsNonLatinCharacters(mappedText)) {
+		return hash || generateMD5(text);
+	}
 
 	// 2. Convert to lowercase
 	const lowercasedText = mappedText.toLowerCase();
@@ -115,6 +121,20 @@ export function generateSlug(text: string, hash?: string): string {
 	// 6. Handle empty string case
 	if (!trimmedText) return "";
 
-	// 7. Limit length
-	return trimmedText.substring(0, 50);
+	// 7. Disambiguate transliterated text from its ASCII equivalent while keeping
+	// the readable portion and the complete slug within the length limit.
+	if (wasTransliterated) {
+		const suffix = (hash || generateMD5(text))
+			.toLowerCase()
+			.replace(/[^a-z0-9]/g, "")
+			.slice(0, HASH_SUFFIX_LENGTH);
+		const readableLength = MAX_SLUG_LENGTH - suffix.length - 1;
+		const readableSlug = trimmedText
+			.substring(0, readableLength)
+			.replace(/-+$/g, "");
+		return `${readableSlug}-${suffix}`;
+	}
+
+	// 8. Limit length
+	return trimmedText.substring(0, MAX_SLUG_LENGTH);
 }


### PR DESCRIPTION
## Summary

- Consolidates compatible dependency updates from #260 and #265 into one reviewed maintenance change.
- Applies bounded reliability, data-integrity, accessibility, and code-quality fixes found during the repository maintenance pass.
- Defers TypeScript 7 from #266 to #268 because Next.js 16.2.10 cannot complete a production build with it.

## Changes

### Dependencies

- **package.json / pnpm-lock.yaml**: Update Babel helpers, Node types, Clerk, Biome, Tailwind, PostCSS, lucide-react, tsx, and related compatible packages.
- **Tailwind configuration**: Replace the outdated animation plugin with Tailwind 4-compatible animation support.
- **Runtime constraints**: Align the Node engine range with supported dependency requirements.

### Reliability and data integrity

- **Rate limiting**: Isolate counters by policy and stop trusting forwarded client headers when no trusted proxy hops are configured.
- **Submission moderation**: Make approvals atomic and prevent concurrent or invalid approval/rejection transitions.
- **Message loading**: Preserve backend failures instead of incorrectly returning 404 responses.
- **Sitemap generation**: Parse modification timestamps safely and consistently.
- **Database schema**: Remove an invalid ORM relation.
- **Message slugs**: Restore intended accented-character transliteration and collision handling.

### Accessibility and code quality

- Add accessible names to icon-only controls and improve table/status semantics.
- Restore the aggregate Biome format/import gate and align generated icon/layout styling.
- Ignore the workspace-local .pnpm-store/ directory so worktree-local installs do not pollute Git status.

### Tests

- Add focused coverage for moderation concurrency, rate-limit isolation and proxy trust, sitemap dates, message fetching, schema metadata, and status helpers.
- Update existing component, environment, token, sanitization, and text tests for the maintained behavior.

## Test plan

- [x] pnpm install --frozen-lockfile
- [x] Dependency audit and peer checks
- [x] Biome check
- [x] ESLint
- [x] TypeScript type check
- [x] Jest: 22 suites, 267 tests
- [x] Production build compilation and TypeScript phases
- [x] Integrated JS/TS code review

Local production page-data collection still requires live Clerk and Turso context.

## Tracking

Closes #267

PRs #260 and #265 are included in this combined change.

TypeScript 7 from #266 is intentionally deferred to #268 because Next.js 16.2.10 cannot build with it.

Follow-ups: #269, #270, and #271.