### PR TITLE
perf(messages): bound homepage retrieval and polling

### DIFF
--- a/__tests__/app/api/messages-route.test.ts
+++ b/__tests__/app/api/messages-route.test.ts
@@ -1,0 +1,83 @@
+/** @jest-environment node */
+
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { GET } from "@/app/api/messages/route";
+import { MESSAGE_PAGE_SIZE } from "@/lib/constants";
+import { getMessages } from "@/lib/messages";
+import { applyRateLimit } from "@/lib/rate-limit";
+
+jest.mock("@clerk/nextjs/server", () => ({
+	auth: jest.fn(),
+	currentUser: jest.fn(),
+}));
+
+jest.mock("@/lib/auth", () => ({
+	isUserAdmin: jest.fn(),
+}));
+
+jest.mock("@/lib/authors", () => ({
+	getOrCreateAuthor: jest.fn(),
+}));
+
+jest.mock("@/lib/db", () => ({
+	__esModule: true,
+	default: {
+		execute: jest.fn(),
+	},
+}));
+
+jest.mock("@/lib/messages", () => ({
+	getMessages: jest.fn(),
+}));
+
+jest.mock("@/lib/rate-limit", () => ({
+	applyRateLimit: jest.fn(),
+	RATE_LIMITS: {
+		PUBLIC_READ: { windowMs: 1, maxRequests: 1 },
+		AUTHENTICATED_WRITE: { windowMs: 1, maxRequests: 1 },
+	},
+}));
+
+jest.mock("@/lib/logger", () => ({
+	__esModule: true,
+	default: {
+		error: jest.fn(),
+	},
+}));
+
+type AsyncMock = {
+	mockResolvedValue(value: unknown): void;
+};
+
+const getMessagesMock = getMessages as unknown as AsyncMock;
+const applyRateLimitMock = applyRateLimit as unknown as AsyncMock;
+
+describe("GET /api/messages", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		applyRateLimitMock.mockResolvedValue(null);
+		getMessagesMock.mockResolvedValue([]);
+	});
+
+	it("uses the default bounded page size", async () => {
+		const response = await GET(
+			new Request("https://positive.help/api/messages"),
+		);
+
+		expect(getMessages).toHaveBeenCalledWith(undefined, MESSAGE_PAGE_SIZE);
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Cache-Control")).toContain("public");
+	});
+
+	it("passes validated cursor and limit parameters to message retrieval", async () => {
+		const response = await GET(
+			new Request(
+				"https://positive.help/api/messages?lastId=10&limit=25&t=123",
+			),
+		);
+
+		expect(getMessages).toHaveBeenCalledWith(10, 25);
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Cache-Control")).toContain("no-store");
+	});
+});

--- a/__tests__/components/MessageList.test.tsx
+++ b/__tests__/components/MessageList.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import MessageList, { type Message } from "@/components/MessageList";
-import { MESSAGE_POLL_INTERVAL_MS } from "@/lib/constants";
+import { MESSAGE_PAGE_SIZE, MESSAGE_POLL_INTERVAL_MS } from "@/lib/constants";
 
 // Mock fetch globally
 global.fetch = jest.fn();
@@ -94,6 +94,10 @@ describe("MessageList", () => {
 				}),
 			);
 		});
+
+		const [requestUrl] = mockFetch.mock.calls[0];
+		expect(requestUrl).toEqual(expect.stringContaining("limit=50"));
+		expect(requestUrl).toEqual(expect.stringContaining("lastId=2"));
 	});
 
 	it("shows loading indicator when fetching messages", async () => {
@@ -146,6 +150,34 @@ describe("MessageList", () => {
 		});
 	});
 
+	it("keeps the rendered message window bounded", async () => {
+		const newMessages = Array.from(
+			{ length: MESSAGE_PAGE_SIZE },
+			(_, index): Message => ({
+				id: index + 3,
+				text: `New message ${index + 3}`,
+				date: "2026-01-01",
+				url: `new-message-${index + 3}`,
+			}),
+		);
+		const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => newMessages,
+		} as Response);
+
+		await act(async () => {
+			render(<MessageList initialMessages={mockMessages} />);
+		});
+
+		await waitFor(() => {
+			expect(screen.getAllByRole("link")).toHaveLength(MESSAGE_PAGE_SIZE);
+		});
+		expect(
+			screen.queryByText("This is a positive message"),
+		).not.toBeInTheDocument();
+	});
+
 	it("handles fetch errors gracefully", async () => {
 		const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
 		mockFetch.mockRejectedValueOnce(new Error("Network error"));
@@ -188,12 +220,21 @@ describe("MessageList", () => {
 	});
 
 	it("renders empty list when no messages provided", async () => {
+		const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => [],
+		} as Response);
+
 		await act(async () => {
 			render(<MessageList initialMessages={[]} />);
 		});
 
-		// Should not crash and container should exist
-		const container = document.querySelector(".space-y-3");
-		expect(container).toBeInTheDocument();
+		await waitFor(() => {
+			expect(document.querySelector(".space-y-3")).toBeInTheDocument();
+		});
+		const [requestUrl] = mockFetch.mock.calls[0];
+		expect(requestUrl).toEqual(expect.stringContaining("limit=50"));
+		expect(requestUrl).not.toEqual(expect.stringContaining("lastId="));
 	});
 });

--- a/__tests__/lib/messages.test.ts
+++ b/__tests__/lib/messages.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { MESSAGE_MAX_PAGE_SIZE, MESSAGE_PAGE_SIZE } from "@/lib/constants";
+import client from "@/lib/db";
+import { getMessages } from "@/lib/messages";
+
+jest.mock("@/lib/db", () => ({
+	__esModule: true,
+	default: {
+		execute: jest.fn(),
+	},
+}));
+
+jest.mock("@/lib/logger", () => ({
+	__esModule: true,
+	default: {
+		error: jest.fn(),
+	},
+}));
+
+type ExecuteResult = Awaited<ReturnType<typeof client.execute>>;
+const executeMock = client.execute as jest.MockedFunction<
+	typeof client.execute
+>;
+
+function resultWithRows(rows: Array<Record<string, string | number>>) {
+	return { rows } as unknown as ExecuteResult;
+}
+
+describe("getMessages", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it("bounds initial retrieval to the default newest-first page", async () => {
+		executeMock.mockResolvedValue(
+			resultWithRows([
+				{ id: 2, text: "Second", date: "2026-01-02", url: "second" },
+				{ id: 1, text: "First", date: "2026-01-01", url: "first" },
+			]),
+		);
+
+		await expect(getMessages()).resolves.toHaveLength(2);
+		expect(executeMock).toHaveBeenCalledWith({
+			sql: expect.stringMatching(/ORDER BY id DESC LIMIT \?/),
+			args: [MESSAGE_PAGE_SIZE],
+		});
+	});
+
+	it("selects the oldest unseen page before returning it newest-first", async () => {
+		executeMock.mockResolvedValue(
+			resultWithRows([
+				{ id: 11, text: "Eleven", date: "2026-01-11", url: "eleven" },
+				{ id: 12, text: "Twelve", date: "2026-01-12", url: "twelve" },
+			]),
+		);
+
+		await expect(getMessages(10, 2)).resolves.toEqual([
+			expect.objectContaining({ id: 12 }),
+			expect.objectContaining({ id: 11 }),
+		]);
+		expect(executeMock).toHaveBeenCalledWith({
+			sql: expect.stringMatching(
+				/WHERE id > \?[\s\S]*ORDER BY id ASC LIMIT \?/,
+			),
+			args: [10, 2],
+		});
+	});
+
+	it("defensively caps direct callers at the maximum page size", async () => {
+		executeMock.mockResolvedValue(resultWithRows([]));
+
+		await getMessages(undefined, MESSAGE_MAX_PAGE_SIZE + 1);
+
+		expect(executeMock).toHaveBeenCalledWith(
+			expect.objectContaining({ args: [MESSAGE_MAX_PAGE_SIZE] }),
+		);
+	});
+});

--- a/__tests__/lib/validation/schemas.test.ts
+++ b/__tests__/lib/validation/schemas.test.ts
@@ -1,6 +1,21 @@
 import { formSchemas, messageSchemas } from "@/lib/validation/schemas";
 
 describe("Validation Schemas with Sanitization", () => {
+	describe("messageSchemas.query", () => {
+		it("accepts bounded message page limits", () => {
+			expect(messageSchemas.query.parse({ limit: "50" })).toEqual({
+				limit: 50,
+			});
+		});
+
+		it.each(["0", "101", "not-a-number"])(
+			"rejects an invalid message page limit of %s",
+			(limit) => {
+				expect(() => messageSchemas.query.parse({ limit })).toThrow();
+			},
+		);
+	});
+
 	describe("messageSchemas.create", () => {
 		it("should sanitize XSS attacks in message text", () => {
 			const maliciousInput = {

--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -2,7 +2,7 @@ import { auth, currentUser } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 import { isUserAdmin } from "@/lib/auth";
 import { getOrCreateAuthor } from "@/lib/authors";
-import { CACHE_MAX_AGE_SECONDS } from "@/lib/constants";
+import { CACHE_MAX_AGE_SECONDS, MESSAGE_PAGE_SIZE } from "@/lib/constants";
 import client from "@/lib/db";
 import { APIError, handleAPIError } from "@/lib/error-handler";
 import logger from "@/lib/logger";
@@ -30,10 +30,10 @@ export async function GET(request: Request) {
 		);
 
 		// Extract validated parameters
-		const { lastId, t } = validatedQuery;
+		const { lastId, limit = MESSAGE_PAGE_SIZE, t } = validatedQuery;
 		const bypassCache = t !== undefined;
 
-		const messages = await getMessages(lastId);
+		const messages = await getMessages(lastId, limit);
 
 		// Set appropriate cache control headers based on the request
 		const headers = new Headers();

--- a/components/MessageList.tsx
+++ b/components/MessageList.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
 import clientLogger from "@/lib/client-logger";
-import { MESSAGE_POLL_INTERVAL_MS } from "@/lib/constants";
+import { MESSAGE_PAGE_SIZE, MESSAGE_POLL_INTERVAL_MS } from "@/lib/constants";
 import { MessageListSkeleton } from "./MessageSkeleton";
 
 export interface Message {
@@ -45,17 +45,22 @@ export default function MessageList({ initialMessages }: MessageListProps) {
 					? Math.max(...currentMessages.map((msg) => msg.id))
 					: 0;
 
-			// Add cache-busting and lastId parameters to only fetch new messages
-			const response = await fetch(
-				`/api/messages?t=${Date.now()}&lastId=${highestId}`,
-				{
-					cache: "no-store",
-					headers: {
-						"Cache-Control": "no-cache",
-						Pragma: "no-cache",
-					},
+			const searchParams = new URLSearchParams({
+				t: Date.now().toString(),
+				limit: MESSAGE_PAGE_SIZE.toString(),
+			});
+			if (highestId > 0) {
+				searchParams.set("lastId", highestId.toString());
+			}
+
+			// Poll only the bounded page after the latest message already displayed.
+			const response = await fetch(`/api/messages?${searchParams}`, {
+				cache: "no-store",
+				headers: {
+					"Cache-Control": "no-cache",
+					Pragma: "no-cache",
 				},
-			);
+			});
 
 			if (!response.ok) {
 				throw new Error("Failed to fetch latest messages");
@@ -73,7 +78,7 @@ export default function MessageList({ initialMessages }: MessageListProps) {
 						new Map(combined.map((msg) => [msg.id, msg])).values(),
 					).sort((a, b) => b.id - a.id);
 
-					return uniqueMessages;
+					return uniqueMessages.slice(0, MESSAGE_PAGE_SIZE);
 				});
 			}
 		} catch (error) {

--- a/docs/message-api.md
+++ b/docs/message-api.md
@@ -1,0 +1,20 @@
+# Message collection API
+
+`GET /api/messages` returns a JSON array of messages ordered from newest to
+oldest. The array response is retained for compatibility with existing
+consumers.
+
+## Query parameters
+
+- `limit` is optional, defaults to 50, and must be between 1 and 100. Every
+  response is bounded by this value.
+- `lastId` is an optional positive-integer cursor. When present, the endpoint
+  returns only messages with a larger ID. Incremental pages are selected from
+  oldest to newest before being returned in the normal newest-first order, so
+  advancing the cursor cannot skip a burst larger than one page.
+- `t` remains an optional cache-busting timestamp for polling requests.
+
+The next `lastId` is the largest message ID received so far. Callers may request
+again with that cursor to continue through newly published messages. An initial
+request without `lastId` returns only the newest page rather than the complete
+message table.

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -8,6 +8,12 @@
 export const MESSAGE_POLL_INTERVAL_MS = 30000;
 
 /**
+ * Default and maximum number of messages returned by the collection endpoint.
+ */
+export const MESSAGE_PAGE_SIZE = 50;
+export const MESSAGE_MAX_PAGE_SIZE = 100;
+
+/**
  * Cache max age for API responses (in seconds)
  */
 export const CACHE_MAX_AGE_SECONDS = 300;

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -1,4 +1,5 @@
 import type { InValue, Row } from "@libsql/client";
+import { MESSAGE_MAX_PAGE_SIZE, MESSAGE_PAGE_SIZE } from "@/lib/constants";
 import client from "@/lib/db";
 import logger from "@/lib/logger";
 
@@ -13,10 +14,20 @@ export interface Message {
 /**
  * Fetches messages from the database
  * @param lastId Optional ID to fetch messages after
+ * @param limit Maximum number of messages to return
  * @returns Array of messages
  */
-export async function getMessages(lastId?: number): Promise<Message[]> {
+export async function getMessages(
+	lastId?: number,
+	limit = MESSAGE_PAGE_SIZE,
+): Promise<Message[]> {
 	try {
+		const boundedLimit = Math.min(
+			Math.max(Math.trunc(limit), 1),
+			MESSAGE_MAX_PAGE_SIZE,
+		);
+		const isIncremental = lastId !== undefined && lastId > 0;
+
 		// Build the SQL query using parameterized queries
 		let sql = `
         SELECT id, msg as text, slug as url, date
@@ -25,26 +36,30 @@ export async function getMessages(lastId?: number): Promise<Message[]> {
 
 		const params: InValue[] = [];
 
-		if (lastId !== undefined && lastId > 0) {
+		if (isIncremental) {
 			sql += ` WHERE id > ? `;
 			params.push(lastId);
 		}
 
-		sql += ` ORDER BY id DESC `;
+		// Incremental queries select the oldest unseen IDs first so advancing the
+		// cursor cannot skip messages when more than one page arrives between polls.
+		sql += ` ORDER BY id ${isIncremental ? "ASC" : "DESC"} LIMIT ? `;
+		params.push(boundedLimit);
 
 		const result = await client.execute({
 			sql,
 			args: params,
 		});
 
-		const messages = result.rows.map((row: Row) => ({
+		const fetchedMessages = result.rows.map((row: Row) => ({
 			id: row.id as number,
 			text: row.text as string,
 			date: row.date as string,
 			url: row.url as string,
 		}));
 
-		return messages;
+		// The public response contract remains newest-first for all query modes.
+		return isIncremental ? fetchedMessages.reverse() : fetchedMessages;
 	} catch (error) {
 		// Log then re-throw. Swallowing the error into an empty array would
 		// let a transient DB failure surface as a cacheable empty 200 response

--- a/lib/validation/schemas.ts
+++ b/lib/validation/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { MESSAGE_MAX_PAGE_SIZE } from "@/lib/constants";
 import { sanitizeContent } from "@/utils/sanitize";
 
 // Common validation patterns
@@ -42,6 +43,16 @@ export const messageSchemas = {
 
 	// For GET /api/messages query parameters
 	query: z.object({
+		limit: z
+			.string()
+			.regex(/^\d+$/, "limit must be a positive integer")
+			.transform((val) => parseInt(val, 10))
+			.refine((val) => val > 0, "limit must be greater than 0")
+			.refine(
+				(val) => val <= MESSAGE_MAX_PAGE_SIZE,
+				`limit must be at most ${MESSAGE_MAX_PAGE_SIZE}`,
+			)
+			.optional(),
 		lastId: z
 			.string()
 			.regex(/^\d+$/, "lastId must be a positive integer")


### PR DESCRIPTION
## Summary

- Default collection retrieval to 50 messages and validate configurable limits from 1–100.
- Retain the existing JSON array and lastId cursor for compatibility.
- Select incremental pages oldest-unseen-first before returning newest-first, preventing cursor gaps during bursts.
- Send explicit bounded polling requests, omit the invalid zero cursor for an empty page, and cap rendered client state at 50.
- Document the collection contract and add API, query, retrieval, and client coverage.

## Testing

- Focused: 4 suites / 29 tests passed.
- just check: formatting, lint, 25 suites / 292 tests, TypeScript, and production build passed.
- pnpm knip: report-only baseline completed with no new findings.

Closes #270